### PR TITLE
Version 3.0 - Professional Scattering Data Analysis Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
-# TUBAF Scattering Plot Tool
+# TUBAF Scattering Plot Tool v3.0
 
-Ein Python-basiertes Darstellungsprogramm für Streukurven mit grafischer Benutzeroberfläche.
+Professionelles Python-Tool für Streudaten-Analyse mit erweiterter Funktionalität.
 
 ## Features
 
+### Plot-Typen
+- **Log-Log**: Klassische doppelt-logarithmische Darstellung
+- **Porod-Plot**: I·q⁴ vs q für Porod-Analyse
+- **Kratky-Plot**: I·q² vs q für strukturelle Charakterisierung
+- **Guinier-Plot**: ln(I) vs q² für Radius of Gyration
+- **PDDF-Modus**: Mit separatem Subplot für Pair Distance Distribution Function
+
 ### Datenverwaltung
-- **Grafische Benutzeroberfläche** mit Tkinter
-- **Drag & Drop**: Ziehen Sie Datensätze zwischen Gruppen per Drag & Drop
-- **Flexible Datenformate**: Unterstützt Tab-, Komma- und Semikolon-getrennte ASCII-Dateien
-- **Gruppenverwaltung**: Organisieren Sie Datensätze in Gruppen (z.B. Messdaten + Fitdaten)
-- **Kontextmenü**: Rechtsklick für schnellen Zugriff auf Bearbeitungsfunktionen
+- **"Nicht zugeordnet" Sektion**: Dateien erst laden, dann per Drag & Drop zuordnen
+- **Drag & Drop**: Intuitive Datensatz-Organisation zwischen Gruppen
+- **Flexible Datenformate**: Automatische Erkennung (Tab, Komma, Semikolon)
+- **Gruppenverwaltung**: Mit individuellen Stack-Faktoren für gestackte Darstellung
+- **Kontextmenü**: Rechtsklick für schnellen Zugriff
+
+### Stil-System
+- **Stil-Vorlagen**: Vordefinierte Stile (Messung, Fit, Simulation, Theorie)
+- **Auto-Erkennung**: Automatische Stil-Zuweisung basierend auf Dateinamen
+- **Design-Manager**: Zentrale Verwaltung von Stilen, Farben und Auto-Regeln
+- **Individuelle Anpassung**: Linientyp, Marker, Größen pro Datensatz
+- **Farbschema-Manager**: TUBAF + alle matplotlib colormaps + eigene Schemata
 
 ### Visualisierung
-- **Gestackte Ansicht**: Log-Log-Plots mit vertikalem Stacking mittels Multiplikationsfaktoren
-- **Fehlervisualisierung**: Fehler werden als transparente Flächen um die Daten dargestellt
-- **TUBAF-Farbpalette**: Offizielle TUBAF Corporate Design Farben
-- **Individuelle Anpassung**: Farben, Linientypen und Marker für jeden Datensatz änderbar
-- **Individuelle Labels**: Datensätze können umbenannt werden
-- **4K Display-Unterstützung**: Scharfe Darstellung auf High-DPI Displays
-
-### Stil-Einstellungen
-- **Linientyp**: Durchgezogen, gestrichelt, gepunktet, etc.
-- **Marker**: Kreise, Quadrate, Dreiecke, Kreuze, etc.
-- **Größen**: Linienbreite und Markergröße anpassbar
-- **Grid-Optionen**: Anpassbare Grid-Darstellung
+- **Gruppen-Header in Legende**: Klare Struktur mit Stack-Faktoren
+- **Individuelle Legendeneinträge**: Jeder Datensatz separat sichtbar
+- **Fehlervisualisierung**: Transparente Flächen um Daten
+- **Achsenbereiche**: Manuell oder automatisch einstellbar
+- **Legende-Position**: Frei wählbar
+- **4K Display-Unterstützung**: DPI-Awareness für scharfe Darstellung
 
 ### Export & Session
-- **PNG Export**: Mit einstellbarer DPI (72-1200 dpi)
-- **SVG Export**: Vektorgrafik für hochwertige Publikationen
-- **Session speichern/laden**: Speichern Sie Ihre Arbeit inkl. aller Einstellungen
+- **PNG Export**: Mit DPI-Einstellung (72-1200), Wert wird gespeichert
+- **SVG Export**: Vektorgrafik für Publikationen
+- **Session speichern/laden**: Komplette Arbeitsumgebung inkl. Plot-Typ
 
 ## Installation
 
@@ -53,42 +61,48 @@ python scatter_plot.py
 
 ### Workflow
 
-1. **Neue Gruppe erstellen**
-   - Klicken Sie auf "➕ Neue Gruppe"
-   - Geben Sie einen Namen ein (z.B. "Probe A - Messung")
-   - Geben Sie einen Stack-Faktor ein (z.B. 1, 10, 100)
+1. **Daten laden (vereinfacht!)**
+   - Klicken Sie auf "📁 Laden" oder Menü → Datei → Daten laden
+   - Dateien werden in "Nicht zugeordnet" abgelegt
+   - **Auto-Stil-Erkennung** wendet passende Stile an
 
-2. **Daten laden**
-   - Klicken Sie auf "📁 Daten laden"
-   - Wählen Sie Datendateien aus
-   - Weisen Sie einer Gruppe zu
+2. **Gruppen erstellen**
+   - Klicken Sie auf "➕ Gruppe"
+   - Namen und Stack-Faktor eingeben (z.B. "Probe A", Faktor 1)
 
-3. **Drag & Drop verwenden**
-   - Ziehen Sie Datensätze zwischen Gruppen
-   - Organisieren Sie Ihre Daten intuitiv
+3. **Drag & Drop zuordnen**
+   - Ziehen Sie Dateien aus "Nicht zugeordnet" auf Gruppen
+   - Verschieben Sie zwischen Gruppen
+   - Zurück zu "Nicht zugeordnet" möglich
 
-4. **Anpassungen vornehmen**
-   - **Rechtsklick** auf Gruppe/Datensatz für Kontextmenü
-   - **Farbe ändern**: Individuelle Farben für Gruppen und Datensätze
-   - **Stil ändern**: Linientyp, Marker, Größen anpassen
-   - **Umbenennen**: Labels für bessere Lesbarkeit ändern
-   - **Doppelklick** auf Gruppe: Stack-Faktor ändern
-   - **Doppelklick** auf Datensatz: Schnell umbenennen
+4. **Plot-Typ wählen**
+   - Dropdown: Log-Log, Porod, Kratky, Guinier, PDDF
+   - Achsenbeschriftung passt sich automatisch an
 
-5. **Plot-Einstellungen**
-   - Menü → Plot → Einstellungen
-   - X/Y-Achsen Labels anpassen
-   - Grid-Optionen einstellen
-   - Schriftgrößen ändern
+5. **Farbschema wählen**
+   - Dropdown: TUBAF, viridis, tab10, Set1, ... (über 30 Schemata!)
+   - Oder eigenes Schema im Design-Manager erstellen
 
-6. **Exportieren**
-   - Menü → Datei → Exportieren als PNG (mit DPI-Auswahl)
-   - Menü → Datei → Exportieren als SVG
+6. **Anpassungen**
+   - **Rechtsklick** → Farbe/Stil ändern, Umbenennen
+   - **Doppelklick** Gruppe → Stack-Faktor
+   - **Doppelklick** "Nicht zugeordnet" → Ein-/Ausklappen
+   - Menü → Design → Stil anwenden (Messung/Fit/etc.)
 
-7. **Session speichern**
-   - Menü → Datei → Session speichern
-   - Alle Einstellungen und Gruppierungen werden gespeichert
-   - Später wieder laden mit: Datei → Session laden
+7. **Erweiterte Einstellungen**
+   - Plot → Erweiterte Einstellungen
+     - Achsenbereiche (Min/Max oder Auto)
+     - Legende-Position
+     - Schriftgrößen
+   - Design → Design-Manager
+     - Stil-Vorlagen verwalten
+     - Farbschemata erstellen
+     - Auto-Erkennungs-Regeln anpassen
+
+8. **Speichern**
+   - Session speichern (JSON) → Alles inkl. Plot-Typ
+   - PNG Export (mit DPI-Merken)
+   - SVG Export
 
 ### Datenformat
 

--- a/scatter_plot.py
+++ b/scatter_plot.py
@@ -1,125 +1,121 @@
 #!/usr/bin/env python3
 """
-Scattering Plot Tool für TUBAF
-Grafische Oberfläche zur Darstellung von Streukurven mit Gruppierung und gestackter Ansicht
+TUBAF Scattering Plot Tool - Version 3.0
+========================================
 
-Features:
-- Drag & Drop für Gruppenzuordnung
-- Individuelle Farb-, Stil- und Label-Anpassung
-- PNG/SVG Export mit DPI-Einstellungen
-- Session speichern/laden
-- 4K DPI-Unterstützung
+Professionelles Tool für Streudaten-Analyse mit:
+- Verschiedene Plot-Typen (Log-Log, Porod, Kratky, Guinier, PDDF)
+- Stil-Vorlagen und Auto-Erkennung
+- Farbschema-Manager
+- Drag & Drop
+- Session-Verwaltung
 """
 
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox, simpledialog, colorchooser
 import matplotlib
-matplotlib.use('TkAgg')  # Backend für bessere Performance
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
+from matplotlib.gridspec import GridSpec
 import numpy as np
 from pathlib import Path
 import json
 import platform
-import sys
 
 from data_loader import load_scattering_data
+from user_config import get_user_config
 
-# TUBAF Farben importieren
-try:
-    from tu_freiberg_colors import PRIMARY, SECONDARY, TERTIARY, get_profile_colors
-    # Standard-Farbpalette für Plots erstellen
-    DEFAULT_COLORS = [
-        PRIMARY['uniblau']['hex'],
-        SECONDARY['geo']['hex'],
-        SECONDARY['material']['hex'],
-        SECONDARY['energie']['hex'],
-        SECONDARY['umwelt']['hex'],
-        TERTIARY['orange_2']['hex'],
-        TERTIARY['gruen_3']['hex'],
-        TERTIARY['tuerkis_2']['hex'],
-        TERTIARY['rot_6']['hex'],
-        TERTIARY['blau_2']['hex'],
-    ]
-except ImportError:
-    # Fallback falls tu_freiberg_colors nicht verfügbar
-    DEFAULT_COLORS = ['#0069b4', '#8b7530', '#007b99', '#b71e3f', '#15882e',
-                      '#e18409', '#95c11f', '#1e959a', '#cd1222', '#a1d9ef']
+# Plot-Typen
+PLOT_TYPES = {
+    'Log-Log': {'xlabel': 'q / nm⁻¹', 'ylabel': 'I / a.u.', 'xscale': 'log', 'yscale': 'log'},
+    'Porod': {'xlabel': 'q / nm⁻¹', 'ylabel': 'I·q⁴ / a.u.·nm⁻⁴', 'xscale': 'log', 'yscale': 'log'},
+    'Kratky': {'xlabel': 'q / nm⁻¹', 'ylabel': 'I·q² / a.u.·nm⁻²', 'xscale': 'linear', 'yscale': 'linear'},
+    'Guinier': {'xlabel': 'q² / nm⁻²', 'ylabel': 'ln(I)', 'xscale': 'linear', 'yscale': 'linear'},
+    'PDDF': {'xlabel': 'q / nm⁻¹', 'ylabel': 'I / a.u.', 'xscale': 'log', 'yscale': 'log'}
+}
 
-
-# ============================================================================
-# DPI Awareness für 4K Displays
-# ============================================================================
 
 def enable_dpi_awareness():
-    """Aktiviert DPI Awareness für scharfe Darstellung auf 4K Displays"""
+    """Aktiviert DPI Awareness für 4K Displays"""
     try:
         if platform.system() == 'Windows':
-            # Windows DPI Awareness
             from ctypes import windll
             windll.shcore.SetProcessDpiAwareness(1)
-        elif platform.system() == 'Linux':
-            # Linux/X11 DPI Scaling
-            pass  # Wird über Tk scalingFactor gehandhabt
-    except Exception as e:
-        print(f"DPI Awareness konnte nicht aktiviert werden: {e}")
+    except:
+        pass
 
-
-# ============================================================================
-# Datenklassen
-# ============================================================================
 
 class DataSet:
-    """Repräsentiert einen einzelnen Datensatz"""
-    def __init__(self, filepath, name=None):
+    """Datensatz mit Stil-Informationen"""
+    def __init__(self, filepath, name=None, apply_auto_style=True):
         self.filepath = Path(filepath)
         self.name = name or self.filepath.stem
-        self.display_label = self.name  # Anzeigename (editierbar)
+        self.display_label = self.name
         self.data = None
         self.x = None
         self.y = None
         self.y_err = None
-
-        # Plot-Stil Einstellungen
-        self.line_style = None  # None = auto
-        self.marker_style = None  # None = auto
-        self.color = None  # None = Gruppenfarbe verwenden
+        
+        # Stil
+        self.line_style = None
+        self.marker_style = None
+        self.color = None
         self.line_width = 2
         self.marker_size = 4
         self.show_in_legend = True
-
+        
         self.load_data()
-
+        
+        # Auto-Stil anwenden
+        if apply_auto_style:
+            self.apply_auto_style()
+    
     def load_data(self):
-        """Lädt die Daten aus der Datei"""
+        """Lädt Daten"""
         try:
             self.data = load_scattering_data(self.filepath)
             self.x = self.data[:, 0]
             self.y = self.data[:, 1]
             if self.data.shape[1] > 2:
                 self.y_err = self.data[:, 2]
-            else:
-                self.y_err = None
         except Exception as e:
             raise ValueError(f"Fehler beim Laden von {self.filepath}: {e}")
-
+    
+    def apply_auto_style(self):
+        """Wendet automatisch erkannten Stil an"""
+        config = get_user_config()
+        style = config.get_style_by_filename(self.filepath)
+        if style:
+            self.line_style = style.get('line_style')
+            self.marker_style = style.get('marker_style')
+            self.line_width = style.get('line_width', 2)
+            self.marker_size = style.get('marker_size', 4)
+    
+    def apply_style_preset(self, preset_name):
+        """Wendet Stil-Vorlage an"""
+        config = get_user_config()
+        if preset_name in config.style_presets:
+            style = config.style_presets[preset_name]
+            self.line_style = style.get('line_style')
+            self.marker_style = style.get('marker_style')
+            self.line_width = style.get('line_width', 2)
+            self.marker_size = style.get('marker_size', 4)
+    
     def get_plot_style(self):
-        """Gibt den Plot-Stil zurück (auto oder manuell gesetzt)"""
-        line_style = self.line_style
-        marker_style = self.marker_style
-
-        if line_style is None:
-            # Auto-Erkennung: Fits bekommen Linien, Messungen Punkte
-            line_style = '-' if 'fit' in self.name.lower() else ''
-
-        if marker_style is None:
-            marker_style = '' if 'fit' in self.name.lower() else 'o'
-
-        return line_style + marker_style
-
+        """Gibt Plot-Stil zurück"""
+        line = self.line_style if self.line_style else ''
+        marker = self.marker_style if self.marker_style else ''
+        if not line and not marker:
+            # Auto: Fit=Linie, sonst Marker
+            if 'fit' in self.name.lower():
+                return '-'
+            return 'o'
+        return line + marker
+    
     def to_dict(self):
-        """Serialisiert den Datensatz für Session-Speicherung"""
+        """Serialisierung"""
         return {
             'filepath': str(self.filepath),
             'name': self.name,
@@ -131,41 +127,38 @@ class DataSet:
             'marker_size': self.marker_size,
             'show_in_legend': self.show_in_legend
         }
-
+    
     @classmethod
     def from_dict(cls, data):
-        """Lädt Datensatz aus gespeicherten Daten"""
-        dataset = cls(data['filepath'], data.get('name'))
-        dataset.display_label = data.get('display_label', dataset.name)
-        dataset.line_style = data.get('line_style')
-        dataset.marker_style = data.get('marker_style')
-        dataset.color = data.get('color')
-        dataset.line_width = data.get('line_width', 2)
-        dataset.marker_size = data.get('marker_size', 4)
-        dataset.show_in_legend = data.get('show_in_legend', True)
-        return dataset
+        """Deserialisierung"""
+        ds = cls(data['filepath'], data.get('name'), apply_auto_style=False)
+        ds.display_label = data.get('display_label', ds.name)
+        ds.line_style = data.get('line_style')
+        ds.marker_style = data.get('marker_style')
+        ds.color = data.get('color')
+        ds.line_width = data.get('line_width', 2)
+        ds.marker_size = data.get('marker_size', 4)
+        ds.show_in_legend = data.get('show_in_legend', True)
+        return ds
 
 
 class DataGroup:
-    """Repräsentiert eine Gruppe von Datensätzen"""
+    """Datengruppe"""
     def __init__(self, name, stack_factor=1.0):
         self.name = name
         self.datasets = []
         self.stack_factor = stack_factor
-        self.color = None  # None = Auto-Farbe
+        self.color = None
         self.show_group_in_legend = True
-
+    
     def add_dataset(self, dataset):
-        """Fügt einen Datensatz zur Gruppe hinzu"""
         self.datasets.append(dataset)
-
+    
     def remove_dataset(self, dataset):
-        """Entfernt einen Datensatz aus der Gruppe"""
         if dataset in self.datasets:
             self.datasets.remove(dataset)
-
+    
     def to_dict(self):
-        """Serialisiert die Gruppe für Session-Speicherung"""
         return {
             'name': self.name,
             'stack_factor': self.stack_factor,
@@ -173,10 +166,9 @@ class DataGroup:
             'show_group_in_legend': self.show_group_in_legend,
             'datasets': [ds.to_dict() for ds in self.datasets]
         }
-
+    
     @classmethod
     def from_dict(cls, data):
-        """Lädt Gruppe aus gespeicherten Daten"""
         group = cls(data['name'], data.get('stack_factor', 1.0))
         group.color = data.get('color')
         group.show_group_in_legend = data.get('show_group_in_legend', True)
@@ -185,900 +177,1274 @@ class DataGroup:
                 dataset = DataSet.from_dict(ds_data)
                 group.add_dataset(dataset)
             except Exception as e:
-                print(f"Fehler beim Laden von Datensatz: {e}")
+                print(f"Fehler beim Laden: {e}")
         return group
 
 
-# ============================================================================
-# Haupt-Anwendung
-# ============================================================================
-
 class ScatterPlotApp:
-    """Hauptanwendung für Scattering Plot Tool"""
-
+    """Hauptanwendung"""
+    
     def __init__(self, root):
         self.root = root
-        self.root.title("TUBAF Scattering Plot Tool")
+        self.root.title("TUBAF Scattering Plot Tool v3.0")
         self.root.geometry("1600x1000")
-
-        # Datenverwaltung
+        
+        # Config
+        self.config = get_user_config()
+        
+        # Daten
         self.groups = []
-        self.color_palette = DEFAULT_COLORS.copy()
-
+        self.unassigned_datasets = []
+        
         # Plot-Einstellungen
+        self.current_plot_type = 'Log-Log'
+        self.stack_mode_var = None
+        self.grid_var = None
+        self.color_scheme = 'TUBAF'
+        
         self.plot_settings = {
-            'stack_mode': True,
             'xlabel': 'q / nm⁻¹',
             'ylabel': 'Intensität / a.u.',
+            'xscale': 'log',
+            'yscale': 'log',
             'show_grid': True,
             'grid_which': 'both',
             'grid_alpha': 0.3,
             'legend_fontsize': 10,
             'axis_fontsize': 12,
-            'figure_dpi': 100,
-            'export_dpi': 300,
+            'legend_loc': 'best',
+            'xlim_auto': True,
+            'ylim_auto': True,
+            'xlim': [None, None],
+            'ylim': [None, None],
         }
-
-        # Drag & Drop State
+        
+        # Drag & Drop
         self.drag_data = None
-
-        # GUI erstellen
+        
+        # GUI
         self.create_gui()
         self.create_menu()
-
+    
     def create_menu(self):
-        """Erstellt die Menüleiste"""
+        """Menü"""
         menubar = tk.Menu(self.root)
         self.root.config(menu=menubar)
-
-        # Datei-Menü
+        
+        # Datei
         file_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label="Datei", menu=file_menu)
+        file_menu.add_command(label="Daten laden...", command=self.load_data_to_unassigned)
+        file_menu.add_separator()
         file_menu.add_command(label="Session speichern", command=self.save_session)
         file_menu.add_command(label="Session laden", command=self.load_session)
         file_menu.add_separator()
-        file_menu.add_command(label="Exportieren als PNG", command=self.export_png)
-        file_menu.add_command(label="Exportieren als SVG", command=self.export_svg)
+        file_menu.add_command(label="PNG Export...", command=self.export_png)
+        file_menu.add_command(label="SVG Export...", command=self.export_svg)
         file_menu.add_separator()
         file_menu.add_command(label="Beenden", command=self.root.quit)
-
-        # Plot-Menü
+        
+        # Plot
         plot_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label="Plot", menu=plot_menu)
         plot_menu.add_command(label="Aktualisieren", command=self.update_plot)
-        plot_menu.add_command(label="Einstellungen", command=self.show_plot_settings)
-
-        # Hilfe-Menü
+        plot_menu.add_command(label="Erweiterte Einstellungen...", command=self.show_plot_settings)
+        
+        # Design
+        design_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Design", menu=design_menu)
+        design_menu.add_command(label="Design-Manager...", command=self.show_design_manager)
+        design_menu.add_separator()
+        
+        # Schnell-Stile
+        for preset_name in self.config.style_presets.keys():
+            design_menu.add_command(
+                label=f"Stil '{preset_name}' anwenden",
+                command=lambda p=preset_name: self.apply_style_to_selected(p)
+            )
+        
+        # Hilfe
         help_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label="Hilfe", menu=help_menu)
         help_menu.add_command(label="Über", command=self.show_about)
-
+    
     def create_gui(self):
-        """Erstellt die grafische Benutzeroberfläche"""
-
-        # Hauptcontainer mit Paned Window
+        """GUI erstellen"""
+        # Main Paned Window
         main_paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
         main_paned.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-
-        # Linke Seite: Datenverwaltung
+        
+        # Linke Seite
         left_frame = ttk.Frame(main_paned, width=450)
         main_paned.add(left_frame, weight=1)
-
-        # Rechte Seite: Plot
+        
+        # Rechte Seite
         right_frame = ttk.Frame(main_paned)
         main_paned.add(right_frame, weight=3)
-
-        # === Linke Seite: Kontrollen ===
-
-        # Buttons für Datenverwaltung
-        button_frame = ttk.Frame(left_frame)
-        button_frame.pack(fill=tk.X, padx=5, pady=5)
-
-        ttk.Button(button_frame, text="➕ Neue Gruppe",
-                   command=self.create_group).pack(side=tk.LEFT, padx=2)
-        ttk.Button(button_frame, text="📁 Daten laden",
-                   command=self.load_data_simple).pack(side=tk.LEFT, padx=2)
-        ttk.Button(button_frame, text="🗑 Löschen",
-                   command=self.delete_selected).pack(side=tk.LEFT, padx=2)
-
-        # Treeview für Gruppen und Datensätze
+        
+        # === Linke Seite ===
+        
+        # Buttons
+        btn_frame = ttk.Frame(left_frame)
+        btn_frame.pack(fill=tk.X, padx=5, pady=5)
+        
+        ttk.Button(btn_frame, text="➕ Gruppe", command=self.create_group).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="📁 Laden", command=self.load_data_to_unassigned).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="🗑 Löschen", command=self.delete_selected).pack(side=tk.LEFT, padx=2)
+        
+        # Tree
         tree_frame = ttk.Frame(left_frame)
         tree_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-
-        # Scrollbars
-        tree_scroll_y = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL)
-        tree_scroll_y.pack(side=tk.RIGHT, fill=tk.Y)
-
-        self.tree = ttk.Treeview(tree_frame,
-                                  columns=("info",),
-                                  yscrollcommand=tree_scroll_y.set)
+        
+        tree_scroll = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL)
+        tree_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        
+        self.tree = ttk.Treeview(tree_frame, columns=("info",), yscrollcommand=tree_scroll.set)
         self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        tree_scroll_y.config(command=self.tree.yview)
-
+        tree_scroll.config(command=self.tree.yview)
+        
         self.tree.heading("#0", text="Name")
         self.tree.heading("info", text="Info")
         self.tree.column("info", width=100)
-
-        # Event-Bindings für Drag & Drop und Kontextmenü
+        
+        # Tree Events
         self.tree.bind("<ButtonPress-1>", self.on_tree_press)
         self.tree.bind("<B1-Motion>", self.on_tree_motion)
         self.tree.bind("<ButtonRelease-1>", self.on_tree_release)
         self.tree.bind("<Double-Button-1>", self.on_tree_double_click)
-        self.tree.bind("<Button-3>", self.show_context_menu)  # Rechtsklick
-
-        # Kontext-Menü erstellen
+        self.tree.bind("<Button-3>", self.show_context_menu)
+        
+        # Context Menu
         self.context_menu = tk.Menu(self.root, tearoff=0)
         self.context_menu.add_command(label="Umbenennen", command=self.rename_item)
         self.context_menu.add_command(label="Farbe ändern", command=self.change_color)
         self.context_menu.add_command(label="Stil ändern", command=self.change_style)
         self.context_menu.add_separator()
         self.context_menu.add_command(label="Löschen", command=self.delete_selected)
-
-        # Schnell-Optionen
-        options_frame = ttk.LabelFrame(left_frame, text="Schnell-Optionen")
-        options_frame.pack(fill=tk.X, padx=5, pady=5)
-
-        ttk.Label(options_frame, text="Stack-Modus:").grid(row=0, column=0,
-                                                            sticky=tk.W, padx=5, pady=2)
+        
+        # Unassigned Section erstellen
+        self.unassigned_id = self.tree.insert("", 0, text="▼ Nicht zugeordnet", values=("",), tags=("unassigned_header",))
+        
+        # Optionen
+        opt_frame = ttk.LabelFrame(left_frame, text="Optionen")
+        opt_frame.pack(fill=tk.X, padx=5, pady=5)
+        
+        # Plot-Typ
+        ttk.Label(opt_frame, text="Plot-Typ:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=2)
+        self.plot_type_var = tk.StringVar(value='Log-Log')
+        plot_combo = ttk.Combobox(opt_frame, textvariable=self.plot_type_var,
+                                   values=list(PLOT_TYPES.keys()), state='readonly', width=15)
+        plot_combo.grid(row=0, column=1, sticky=tk.W, padx=5, pady=2)
+        plot_combo.bind('<<ComboboxSelected>>', lambda e: self.change_plot_type())
+        
+        # Stack-Modus
+        ttk.Label(opt_frame, text="Stack:").grid(row=1, column=0, sticky=tk.W, padx=5, pady=2)
         self.stack_mode_var = tk.BooleanVar(value=True)
-        ttk.Checkbutton(options_frame, text="Aktiviert",
-                        variable=self.stack_mode_var,
-                        command=self.update_plot).grid(row=0, column=1,
-                                                        sticky=tk.W, padx=5, pady=2)
-
-        ttk.Label(options_frame, text="Grid:").grid(row=1, column=0,
-                                                     sticky=tk.W, padx=5, pady=2)
+        ttk.Checkbutton(opt_frame, text="Aktiviert", variable=self.stack_mode_var,
+                        command=self.update_plot).grid(row=1, column=1, sticky=tk.W, padx=5, pady=2)
+        
+        # Grid
+        ttk.Label(opt_frame, text="Grid:").grid(row=2, column=0, sticky=tk.W, padx=5, pady=2)
         self.grid_var = tk.BooleanVar(value=True)
-        ttk.Checkbutton(options_frame, text="Anzeigen",
-                        variable=self.grid_var,
-                        command=self.update_plot).grid(row=1, column=1,
-                                                        sticky=tk.W, padx=5, pady=2)
-
-        options_frame.columnconfigure(1, weight=1)
-
-        # Plot-Button
-        plot_button_frame = ttk.Frame(left_frame)
-        plot_button_frame.pack(fill=tk.X, padx=5, pady=5)
-        ttk.Button(plot_button_frame, text="🔄 Plot aktualisieren",
-                   command=self.update_plot).pack(fill=tk.X)
-
-        # === Rechte Seite: Matplotlib Plot ===
-
-        self.fig = Figure(figsize=(12, 9), dpi=self.plot_settings['figure_dpi'])
-        self.ax = self.fig.add_subplot(111)
-
+        ttk.Checkbutton(opt_frame, text="Anzeigen", variable=self.grid_var,
+                        command=self.update_plot).grid(row=2, column=1, sticky=tk.W, padx=5, pady=2)
+        
+        # Farbschema
+        ttk.Label(opt_frame, text="Farbschema:").grid(row=3, column=0, sticky=tk.W, padx=5, pady=2)
+        self.color_scheme_var = tk.StringVar(value='TUBAF')
+        schemes = list(self.config.color_schemes.keys())
+        scheme_combo = ttk.Combobox(opt_frame, textvariable=self.color_scheme_var,
+                                     values=schemes, state='readonly', width=15)
+        scheme_combo.grid(row=3, column=1, sticky=tk.W, padx=5, pady=2)
+        scheme_combo.bind('<<ComboboxSelected>>', lambda e: self.change_color_scheme())
+        
+        # Update Button
+        ttk.Button(left_frame, text="🔄 Plot aktualisieren", command=self.update_plot).pack(fill=tk.X, padx=5, pady=5)
+        
+        # === Rechte Seite: Plot ===
+        
+        self.fig = Figure(figsize=(12, 9), dpi=100)
+        self.ax_main = None
+        self.ax_pddf = None
+        
         self.canvas = FigureCanvasTkAgg(self.fig, master=right_frame)
         self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
-
-        # Matplotlib Toolbar
+        
         toolbar = NavigationToolbar2Tk(self.canvas, right_frame)
         toolbar.update()
-
-        # Initial-Plot
+        
+        self.setup_plot_axes()
         self.update_plot()
-
+    
+    def setup_plot_axes(self):
+        """Richtet Plot-Achsen ein (mit/ohne PDDF Subplot)"""
+        self.fig.clear()
+        
+        if self.current_plot_type == 'PDDF':
+            # 2 Subplots: oben Scattering, unten PDDF
+            gs = GridSpec(2, 1, height_ratios=[2, 1], hspace=0.3, figure=self.fig)
+            self.ax_main = self.fig.add_subplot(gs[0])
+            self.ax_pddf = self.fig.add_subplot(gs[1])
+        else:
+            # Ein Plot
+            self.ax_main = self.fig.add_subplot(111)
+            self.ax_pddf = None
+    
+    def change_plot_type(self):
+        """Ändert Plot-Typ"""
+        self.current_plot_type = self.plot_type_var.get()
+        plot_info = PLOT_TYPES[self.current_plot_type]
+        self.plot_settings['xlabel'] = plot_info['xlabel']
+        self.plot_settings['ylabel'] = plot_info['ylabel']
+        self.plot_settings['xscale'] = plot_info['xscale']
+        self.plot_settings['yscale'] = plot_info['yscale']
+        self.setup_plot_axes()
+        self.update_plot()
+    
+    def change_color_scheme(self):
+        """Ändert Farbschema"""
+        self.color_scheme = self.color_scheme_var.get()
+        self.update_plot()
+    
+    def apply_style_to_selected(self, preset_name):
+        """Wendet Stil auf ausgewählte Datensätze an"""
+        selected = self.tree.selection()
+        if not selected:
+            messagebox.showinfo("Info", "Bitte wählen Sie Datensätze aus")
+            return
+        
+        for item in selected:
+            parent = self.tree.parent(item)
+            if parent and parent != self.unassigned_id:  # Datensatz in Gruppe
+                item_text = self.tree.item(item, 'text')
+                parent_name = self.tree.item(parent, 'text')
+                group = next((g for g in self.groups if g.name == parent_name), None)
+                if group:
+                    ds = next((d for d in group.datasets if d.display_label == item_text), None)
+                    if ds:
+                        ds.apply_style_preset(preset_name)
+            elif parent == self.unassigned_id:  # Unassigned
+                item_text = self.tree.item(item, 'text')
+                ds = next((d for d in self.unassigned_datasets if d.display_label == item_text), None)
+                if ds:
+                    ds.apply_style_preset(preset_name)
+        
+        self.update_plot()
+    
     # ========================================================================
-    # Drag & Drop Funktionalität
+    # Drag & Drop
     # ========================================================================
-
+    
     def on_tree_press(self, event):
-        """Start von Drag & Drop"""
         item = self.tree.identify_row(event.y)
         if item:
             self.drag_data = {'item': item, 'start_y': event.y}
-
+    
     def on_tree_motion(self, event):
-        """Während Drag & Drop"""
         if self.drag_data and abs(event.y - self.drag_data['start_y']) > 5:
-            # Cursor ändern um Drag zu signalisieren
             self.tree.config(cursor="hand2")
-
+    
     def on_tree_release(self, event):
-        """Ende von Drag & Drop"""
         if self.drag_data:
             source_item = self.drag_data['item']
             target_item = self.tree.identify_row(event.y)
-
+            
             if target_item and source_item != target_item:
-                # Prüfen ob Datensatz auf Gruppe gedroppt wird
-                source_parent = self.tree.parent(source_item)
-                target_parent = self.tree.parent(target_item)
-
-                # Datensatz wird auf Gruppe gedroppt
-                if source_parent and not target_parent:
-                    self.move_dataset_to_group(source_item, target_item)
-                # Datensatz wird auf Datensatz gedroppt (zur gleichen Gruppe)
-                elif source_parent and target_parent:
-                    self.move_dataset_to_group(source_item, target_parent)
-
+                self.handle_drop(source_item, target_item)
+            
             self.tree.config(cursor="")
             self.drag_data = None
-
-    def move_dataset_to_group(self, dataset_item, target_group_item):
-        """Verschiebt einen Datensatz in eine andere Gruppe"""
-        # Namen ermitteln
-        dataset_name = self.tree.item(dataset_item, 'text')
-        source_group_name = self.tree.item(self.tree.parent(dataset_item), 'text')
+    
+    def handle_drop(self, source, target):
+        """Verarbeitet Drag & Drop"""
+        source_parent = self.tree.parent(source)
+        target_parent = self.tree.parent(target)
+        
+        # Von Unassigned zu Gruppe
+        if source_parent == self.unassigned_id and not target_parent:
+            self.move_unassigned_to_group(source, target)
+        # Von Gruppe zu Gruppe
+        elif source_parent and target_parent and source_parent != self.unassigned_id:
+            self.move_dataset_between_groups(source, target_parent if target_parent else target)
+        # Von Gruppe zu Unassigned
+        elif source_parent and source_parent != self.unassigned_id and target == self.unassigned_id:
+            self.move_dataset_to_unassigned(source)
+    
+    def move_unassigned_to_group(self, source_item, target_group_item):
+        """Verschiebt von Unassigned zu Gruppe"""
+        dataset_name = self.tree.item(source_item, 'text')
         target_group_name = self.tree.item(target_group_item, 'text')
-
+        
+        dataset = next((d for d in self.unassigned_datasets if d.display_label == dataset_name), None)
+        target_group = next((g for g in self.groups if g.name == target_group_name), None)
+        
+        if dataset and target_group:
+            self.unassigned_datasets.remove(dataset)
+            target_group.add_dataset(dataset)
+            self.tree.delete(source_item)
+            self.tree.insert(target_group_item, tk.END, text=dataset.display_label, values=("",), tags=("dataset",))
+            self.update_plot()
+    
+    def move_dataset_between_groups(self, source_item, target_group_item):
+        """Verschiebt zwischen Gruppen"""
+        dataset_name = self.tree.item(source_item, 'text')
+        source_group_name = self.tree.item(self.tree.parent(source_item), 'text')
+        target_group_name = self.tree.item(target_group_item, 'text')
+        
         if source_group_name == target_group_name:
-            return  # Gleiche Gruppe
-
-        # Datensatz und Gruppen finden
+            return
+        
         source_group = next((g for g in self.groups if g.name == source_group_name), None)
         target_group = next((g for g in self.groups if g.name == target_group_name), None)
-
+        
         if source_group and target_group:
-            dataset = next((d for d in source_group.datasets if d.name == dataset_name), None)
+            dataset = next((d for d in source_group.datasets if d.display_label == dataset_name), None)
             if dataset:
-                # Verschieben
                 source_group.remove_dataset(dataset)
                 target_group.add_dataset(dataset)
-
-                # Tree aktualisieren
-                self.tree.delete(dataset_item)
-                self.tree.insert(target_group_item, tk.END, text=dataset.display_label,
-                               values=("",), tags=("dataset",))
-
+                self.tree.delete(source_item)
+                self.tree.insert(target_group_item, tk.END, text=dataset.display_label, values=("",), tags=("dataset",))
                 self.update_plot()
-
+    
+    def move_dataset_to_unassigned(self, source_item):
+        """Verschiebt zu Unassigned"""
+        dataset_name = self.tree.item(source_item, 'text')
+        source_group_name = self.tree.item(self.tree.parent(source_item), 'text')
+        
+        source_group = next((g for g in self.groups if g.name == source_group_name), None)
+        if source_group:
+            dataset = next((d for d in source_group.datasets if d.display_label == dataset_name), None)
+            if dataset:
+                source_group.remove_dataset(dataset)
+                self.unassigned_datasets.append(dataset)
+                self.tree.delete(source_item)
+                self.tree.insert(self.unassigned_id, tk.END, text=dataset.display_label, values=("",), tags=("dataset",))
+                self.update_plot()
+    
     # ========================================================================
-    # Kontextmenü und Bearbeitungs-Funktionen
+    # Tree Interaktion
     # ========================================================================
-
-    def show_context_menu(self, event):
-        """Zeigt Kontextmenü bei Rechtsklick"""
-        item = self.tree.identify_row(event.y)
-        if item:
-            self.tree.selection_set(item)
-            self.context_menu.post(event.x_root, event.y_root)
-
+    
     def on_tree_double_click(self, event):
-        """Doppelklick zum schnellen Bearbeiten"""
         selected = self.tree.selection()
         if not selected:
             return
-
+        
         item = selected[0]
+        if item == self.unassigned_id:
+            # Toggle Unassigned Section
+            if self.tree.item(item, 'text').startswith('▼'):
+                self.tree.item(item, text='▶ Nicht zugeordnet')
+                for child in self.tree.get_children(item):
+                    self.tree.detach(child)
+            else:
+                self.tree.item(item, text='▼ Nicht zugeordnet')
+                for child in self.tree.get_children(item):
+                    self.tree.reattach(child, item, 'end')
+            return
+        
         parent = self.tree.parent(item)
-
-        if not parent:  # Gruppe
+        if not parent or parent == self.unassigned_id:
+            return
+        
+        if not self.tree.parent(self.tree.parent(item)):  # Gruppe
             self.edit_stack_factor(item)
         else:  # Datensatz
             self.rename_item()
-
+    
+    def show_context_menu(self, event):
+        item = self.tree.identify_row(event.y)
+        if item and item != self.unassigned_id:
+            self.tree.selection_set(item)
+            self.context_menu.post(event.x_root, event.y_root)
+    
     def rename_item(self):
-        """Benennt Gruppe oder Datensatz um"""
         selected = self.tree.selection()
         if not selected:
             return
-
+        
         item = selected[0]
-        item_text = self.tree.item(item, 'text')
-        parent = self.tree.parent(item)
-
-        new_name = simpledialog.askstring("Umbenennen", "Neuer Name:", initialvalue=item_text)
+        old_name = self.tree.item(item, 'text')
+        new_name = simpledialog.askstring("Umbenennen", "Neuer Name:", initialvalue=old_name)
+        
         if not new_name:
             return
-
-        if not parent:  # Gruppe
-            group = next((g for g in self.groups if g.name == item_text), None)
+        
+        parent = self.tree.parent(item)
+        
+        if not parent or parent == self.unassigned_id:
+            return
+        
+        # Gruppe umbenennen
+        if not self.tree.parent(parent):
+            group = next((g for g in self.groups if g.name == old_name), None)
             if group:
                 group.name = new_name
                 self.tree.item(item, text=new_name)
-        else:  # Datensatz
+        # Datensatz umbenennen
+        else:
             parent_name = self.tree.item(parent, 'text')
             group = next((g for g in self.groups if g.name == parent_name), None)
             if group:
-                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
-                if dataset:
-                    dataset.display_label = new_name
+                ds = next((d for d in group.datasets if d.display_label == old_name), None)
+                if ds:
+                    ds.display_label = new_name
                     self.tree.item(item, text=new_name)
-
+        
         self.update_plot()
-
+    
     def change_color(self):
-        """Ändert die Farbe einer Gruppe oder eines Datensatzes"""
+        """Ändert Farbe"""
         selected = self.tree.selection()
         if not selected:
             return
-
+        
         item = selected[0]
         item_text = self.tree.item(item, 'text')
         parent = self.tree.parent(item)
-
-        # Aktuelle Farbe ermitteln
+        
         current_color = '#0069b4'
-        if not parent:  # Gruppe
-            group = next((g for g in self.groups if g.name == item_text), None)
-            if group and group.color:
-                current_color = group.color
-        else:  # Datensatz
+        
+        # Gruppe
+        if not parent or parent == self.unassigned_id:
+            if parent != self.unassigned_id:
+                group = next((g for g in self.groups if g.name == item_text), None)
+                if group and group.color:
+                    current_color = group.color
+        # Datensatz
+        else:
             parent_name = self.tree.item(parent, 'text')
             group = next((g for g in self.groups if g.name == parent_name), None)
             if group:
-                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
-                if dataset and dataset.color:
-                    current_color = dataset.color
-
-        # Farbauswahl-Dialog
+                ds = next((d for d in group.datasets if d.display_label == item_text), None)
+                if ds and ds.color:
+                    current_color = ds.color
+        
         color = colorchooser.askcolor(color=current_color, title="Farbe wählen")
         if not color[1]:
             return
-
+        
         new_color = color[1]
-
-        # Farbe setzen
-        if not parent:  # Gruppe
-            group = next((g for g in self.groups if g.name == item_text), None)
-            if group:
-                group.color = new_color
-        else:  # Datensatz
+        
+        # Setze Farbe
+        if not parent or parent == self.unassigned_id:
+            if parent != self.unassigned_id:
+                group = next((g for g in self.groups if g.name == item_text), None)
+                if group:
+                    group.color = new_color
+        else:
             parent_name = self.tree.item(parent, 'text')
             group = next((g for g in self.groups if g.name == parent_name), None)
             if group:
-                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
-                if dataset:
-                    dataset.color = new_color
-
+                ds = next((d for d in group.datasets if d.display_label == item_text), None)
+                if ds:
+                    ds.color = new_color
+        
         self.update_plot()
-
+    
     def change_style(self):
-        """Ändert den Stil eines Datensatzes (Linientyp, Marker)"""
+        """Ändert Stil"""
         selected = self.tree.selection()
         if not selected:
             return
-
+        
         item = selected[0]
         parent = self.tree.parent(item)
-
-        if not parent:
-            messagebox.showinfo("Info", "Stil kann nur für Datensätze geändert werden")
+        
+        if not parent or parent == self.unassigned_id:
+            if parent == self.unassigned_id:
+                item_text = self.tree.item(item, 'text')
+                ds = next((d for d in self.unassigned_datasets if d.display_label == item_text), None)
+                if ds:
+                    StyleDialog(self.root, ds, self.update_plot)
             return
-
+        
         item_text = self.tree.item(item, 'text')
         parent_name = self.tree.item(parent, 'text')
         group = next((g for g in self.groups if g.name == parent_name), None)
-
-        if not group:
-            return
-
-        dataset = next((d for d in group.datasets if d.display_label == item_text), None)
-        if not dataset:
-            return
-
-        # Dialog für Stil-Einstellungen
-        StyleDialog(self.root, dataset, self.update_plot)
-
+        
+        if group:
+            ds = next((d for d in group.datasets if d.display_label == item_text), None)
+            if ds:
+                StyleDialog(self.root, ds, self.update_plot)
+    
     def edit_stack_factor(self, item=None):
-        """Bearbeitet den Stack-Faktor einer Gruppe"""
         if item is None:
             selected = self.tree.selection()
             if not selected:
                 return
             item = selected[0]
-
-        parent = self.tree.parent(item)
-        if parent:  # Nur für Gruppen
-            return
-
+        
         item_text = self.tree.item(item, 'text')
         group = next((g for g in self.groups if g.name == item_text), None)
-
+        
         if group:
-            new_factor = simpledialog.askfloat("Stack-Faktor bearbeiten",
-                                                f"Neuer Stack-Faktor für '{group.name}':",
-                                                initialvalue=group.stack_factor)
+            new_factor = simpledialog.askfloat(
+                "Stack-Faktor",
+                f"Stack-Faktor für '{group.name}':",
+                initialvalue=group.stack_factor
+            )
             if new_factor is not None:
                 group.stack_factor = new_factor
                 self.tree.item(item, values=(f"×{new_factor}",))
                 self.update_plot()
-
+    
+    def delete_selected(self):
+        selected = self.tree.selection()
+        if not selected:
+            return
+        
+        for item in selected:
+            if item == self.unassigned_id:
+                continue
+            
+            item_text = self.tree.item(item, 'text')
+            parent = self.tree.parent(item)
+            
+            # Unassigned Dataset
+            if parent == self.unassigned_id:
+                ds = next((d for d in self.unassigned_datasets if d.display_label == item_text), None)
+                if ds:
+                    self.unassigned_datasets.remove(ds)
+            # Gruppe
+            elif not parent:
+                group = next((g for g in self.groups if g.name == item_text), None)
+                if group:
+                    self.groups.remove(group)
+            # Datensatz in Gruppe
+            else:
+                parent_name = self.tree.item(parent, 'text')
+                group = next((g for g in self.groups if g.name == parent_name), None)
+                if group:
+                    ds = next((d for d in group.datasets if d.display_label == item_text), None)
+                    if ds:
+                        group.remove_dataset(ds)
+            
+            self.tree.delete(item)
+        
+        self.update_plot()
+    
     # ========================================================================
-    # Daten laden und verwalten
+    # Daten laden
     # ========================================================================
-
+    
     def create_group(self):
-        """Erstellt eine neue Gruppe"""
         name = simpledialog.askstring("Neue Gruppe", "Gruppenname:")
         if not name:
             return
-
-        stack_factor = simpledialog.askfloat("Stack-Faktor",
-                                              "Stack-Faktor (z.B. 1, 10, 100):",
-                                              initialvalue=1.0)
+        
+        stack_factor = simpledialog.askfloat("Stack-Faktor", "Stack-Faktor:", initialvalue=1.0)
         if stack_factor is None:
             stack_factor = 1.0
-
+        
         group = DataGroup(name, stack_factor)
         self.groups.append(group)
-
-        # In Treeview einfügen
-        group_id = self.tree.insert("", tk.END, text=name,
-                                    values=(f"×{stack_factor}",),
-                                    tags=("group",))
+        
+        group_id = self.tree.insert("", tk.END, text=name, values=(f"×{stack_factor}",), tags=("group",))
         self.tree.item(group_id, open=True)
-
-    def load_data_simple(self):
-        """Einfaches Laden von Daten - Dateien wählen, dann Gruppe zuordnen"""
-        # Dateien auswählen
+    
+    def load_data_to_unassigned(self):
+        """Lädt Dateien in Unassigned"""
+        last_dir = self.config.get_last_directory()
+        
         filepaths = filedialog.askopenfilenames(
             title="Datensätze auswählen",
+            initialdir=last_dir,
             filetypes=[("Alle Dateien", "*.*"),
                        ("Text-Dateien", "*.txt"),
                        ("CSV-Dateien", "*.csv"),
                        ("DAT-Dateien", "*.dat")]
         )
-
+        
         if not filepaths:
             return
-
-        # Falls keine Gruppen vorhanden, eine erstellen
-        if not self.groups:
-            self.create_group()
-            if not self.groups:  # Benutzer hat abgebrochen
-                return
-
-        # Gruppe auswählen
-        group_names = [g.name for g in self.groups]
-        if len(group_names) == 1:
-            group_name = group_names[0]
-        else:
-            group_name = simpledialog.askstring("Gruppe wählen",
-                                                f"Gruppenname (verfügbar: {', '.join(group_names)}):")
-
-        group = next((g for g in self.groups if g.name == group_name), None)
-        if not group:
-            messagebox.showerror("Fehler", f"Gruppe '{group_name}' nicht gefunden")
-            return
-
-        # Dateien laden
+        
+        # Speichere Verzeichnis
+        self.config.set_last_directory(str(Path(filepaths[0]).parent))
+        
         for filepath in filepaths:
             try:
-                dataset = DataSet(filepath)
-                group.add_dataset(dataset)
-
-                # In Treeview einfügen
-                for item in self.tree.get_children():
-                    if self.tree.item(item, "text") == group.name:
-                        self.tree.insert(item, tk.END, text=dataset.display_label,
-                                        values=("",), tags=("dataset",))
-                        break
-
+                dataset = DataSet(filepath, apply_auto_style=True)
+                self.unassigned_datasets.append(dataset)
+                self.tree.insert(self.unassigned_id, tk.END, text=dataset.display_label,
+                               values=("",), tags=("dataset",))
             except Exception as e:
-                messagebox.showerror("Fehler", f"Fehler beim Laden von {filepath}:\n{e}")
-
-        self.update_plot()
-
-    def delete_selected(self):
-        """Löscht ausgewählte Gruppe oder Datensatz"""
-        selected = self.tree.selection()
-        if not selected:
-            messagebox.showwarning("Keine Auswahl", "Bitte wählen Sie ein Element aus")
-            return
-
-        for item in selected:
-            item_text = self.tree.item(item, "text")
-            parent = self.tree.parent(item)
-
-            if not parent:  # Gruppe
-                group = next((g for g in self.groups if g.name == item_text), None)
-                if group:
-                    self.groups.remove(group)
-            else:  # Datensatz
-                parent_text = self.tree.item(parent, "text")
-                group = next((g for g in self.groups if g.name == parent_text), None)
-                if group:
-                    dataset = next((d for d in group.datasets if d.display_label == item_text), None)
-                    if dataset:
-                        group.remove_dataset(dataset)
-
-            self.tree.delete(item)
-
-        self.update_plot()
-
+                messagebox.showerror("Fehler", f"Fehler bei {filepath}:\n{e}")
+        
+        # Unassigned aufklappen
+        self.tree.item(self.unassigned_id, text='▼ Nicht zugeordnet')
+    
     # ========================================================================
-    # Plot-Funktionen
+    # Plot
     # ========================================================================
-
+    
+    def transform_data(self, x, y, plot_type):
+        """Transformiert Daten je nach Plot-Typ"""
+        if plot_type == 'Porod':
+            return x, y * (x ** 4)
+        elif plot_type == 'Kratky':
+            return x, y * (x ** 2)
+        elif plot_type == 'Guinier':
+            y_safe = np.where(y > 0, y, np.nan)
+            return x ** 2, np.log(y_safe)
+        else:
+            return x, y
+    
     def update_plot(self):
-        """Aktualisiert den Plot mit allen Gruppen und Datensätzen"""
-        self.ax.clear()
-
+        """Aktualisiert Plot"""
+        self.ax_main.clear()
+        if self.ax_pddf:
+            self.ax_pddf.clear()
+        
         if not self.groups:
-            self.ax.text(0.5, 0.5, "Keine Daten geladen\n\nDateien per Drag & Drop oder '📁 Daten laden'",
-                        ha='center', va='center', transform=self.ax.transAxes,
-                        fontsize=14, color='gray')
+            self.ax_main.text(0.5, 0.5, "Keine Daten\n\nDateien laden und per Drag & Drop zuordnen",
+                             ha='center', va='center', transform=self.ax_main.transAxes,
+                             fontsize=14, color='gray')
             self.canvas.draw()
             return
-
-        # Farbpalette vorbereiten
-        colors = self.color_palette.copy()
-
+        
+        # Farben
+        colors = self.config.color_schemes.get(self.color_scheme, self.config.color_schemes['TUBAF'])
         stack_mode = self.stack_mode_var.get()
-
-        # Plot jede Gruppe
+        
+        # Legende-Handles für Gruppen-Header
+        legend_handles = []
+        legend_labels = []
+        
         for group_idx, group in enumerate(self.groups):
             if not group.datasets:
                 continue
-
-            # Farbe für die Gruppe
+            
             group_color = group.color if group.color else colors[group_idx % len(colors)]
-
-            # Stack-Faktor
             stack_factor = group.stack_factor if stack_mode else 1.0
-
-            # Plot jeden Datensatz in der Gruppe
-            for ds_idx, dataset in enumerate(group.datasets):
+            
+            # Gruppen-Header in Legende
+            if group.show_group_in_legend and stack_mode:
+                from matplotlib.lines import Line2D
+                header_line = Line2D([0], [0], color='none', label=f'━━ {group.name} (×{stack_factor}) ━━')
+                legend_handles.append(header_line)
+                legend_labels.append(f'━━ {group.name} (×{stack_factor}) ━━')
+            
+            for dataset in group.datasets:
                 if dataset.x is None or dataset.y is None:
                     continue
-
-                # Y-Werte mit Stack-Faktor
-                y_plot = dataset.y * stack_factor
-
-                # Farbe: Datensatz-Farbe oder Gruppenfarbe
+                
+                # Transform
+                x_plot, y_plot = self.transform_data(dataset.x, dataset.y, self.current_plot_type)
+                y_plot = y_plot * stack_factor
+                
                 plot_color = dataset.color if dataset.color else group_color
-
-                # Label
-                if dataset.show_in_legend:
-                    if stack_mode and ds_idx == 0:
-                        label = f"{group.name} (×{stack_factor}) - {dataset.display_label}"
-                    else:
-                        label = f"{group.name} - {dataset.display_label}"
-                else:
-                    label = None
-
-                # Plot-Stil
                 plot_style = dataset.get_plot_style()
-
-                # Hauptplot
-                self.ax.plot(dataset.x, y_plot, plot_style,
-                           color=plot_color,
-                           linewidth=dataset.line_width,
-                           markersize=dataset.marker_size,
-                           label=label,
-                           alpha=0.8)
-
-                # Fehlerbereich
+                
+                label = dataset.display_label if dataset.show_in_legend else None
+                
+                line, = self.ax_main.plot(x_plot, y_plot, plot_style,
+                                         color=plot_color,
+                                         linewidth=dataset.line_width,
+                                         markersize=dataset.marker_size,
+                                         label=label,
+                                         alpha=0.8)
+                
+                if dataset.show_in_legend:
+                    legend_handles.append(line)
+                    legend_labels.append(dataset.display_label)
+                
+                # Fehler
                 if dataset.y_err is not None:
-                    y_err_plot = dataset.y_err * stack_factor
-                    self.ax.fill_between(dataset.x,
-                                        y_plot - y_err_plot,
-                                        y_plot + y_err_plot,
-                                        color=plot_color,
-                                        alpha=0.2)
-
-        # Achsen-Einstellungen
-        self.ax.set_xscale('log')
-        self.ax.set_yscale('log')
-        self.ax.set_xlabel(self.plot_settings['xlabel'],
-                          fontsize=self.plot_settings['axis_fontsize'])
-        self.ax.set_ylabel(self.plot_settings['ylabel'],
-                          fontsize=self.plot_settings['axis_fontsize'])
-
+                    _, y_err_plot = self.transform_data(dataset.x, dataset.y_err, self.current_plot_type)
+                    y_err_plot = y_err_plot * stack_factor
+                    self.ax_main.fill_between(x_plot,
+                                              y_plot - y_err_plot,
+                                              y_plot + y_err_plot,
+                                              color=plot_color,
+                                              alpha=0.2)
+        
+        # Achsen
+        self.ax_main.set_xscale(self.plot_settings['xscale'])
+        self.ax_main.set_yscale(self.plot_settings['yscale'])
+        self.ax_main.set_xlabel(self.plot_settings['xlabel'], fontsize=self.plot_settings['axis_fontsize'])
+        self.ax_main.set_ylabel(self.plot_settings['ylabel'], fontsize=self.plot_settings['axis_fontsize'])
+        
         if self.grid_var.get():
-            self.ax.grid(True,
-                        alpha=self.plot_settings['grid_alpha'],
-                        which=self.plot_settings['grid_which'])
-
-        self.ax.legend(fontsize=self.plot_settings['legend_fontsize'],
-                      framealpha=0.9)
-
+            self.ax_main.grid(True, alpha=self.plot_settings['grid_alpha'], which=self.plot_settings['grid_which'])
+        
+        # Limits
+        if not self.plot_settings['xlim_auto']:
+            self.ax_main.set_xlim(self.plot_settings['xlim'])
+        if not self.plot_settings['ylim_auto']:
+            self.ax_main.set_ylim(self.plot_settings['ylim'])
+        
+        # Legende
+        if legend_handles:
+            self.ax_main.legend(handles=legend_handles, labels=legend_labels,
+                               fontsize=self.plot_settings['legend_fontsize'],
+                               loc=self.plot_settings['legend_loc'],
+                               framealpha=0.9)
+        
+        # PDDF Subplot (Platzhalter)
+        if self.ax_pddf:
+            self.ax_pddf.set_xlabel('r / nm', fontsize=self.plot_settings['axis_fontsize'])
+            self.ax_pddf.set_ylabel('p(r)', fontsize=self.plot_settings['axis_fontsize'])
+            self.ax_pddf.text(0.5, 0.5, 'PDDF Darstellung\n(Implementierung erforderlich)',
+                             ha='center', va='center', transform=self.ax_pddf.transAxes)
+            if self.grid_var.get():
+                self.ax_pddf.grid(True, alpha=self.plot_settings['grid_alpha'])
+        
         self.fig.tight_layout()
         self.canvas.draw()
-
+    
+    # ========================================================================
+    # Dialoge
+    # ========================================================================
+    
     def show_plot_settings(self):
-        """Zeigt Dialog für erweiterte Plot-Einstellungen"""
         PlotSettingsDialog(self.root, self.plot_settings, self.update_plot)
-
+    
+    def show_design_manager(self):
+        DesignManagerDialog(self.root, self.config, self.update_plot)
+    
+    def show_about(self):
+        messagebox.showinfo("Über", 
+            "TUBAF Scattering Plot Tool v3.0\n\n"
+            "Features:\n"
+            "• Verschiedene Plot-Typen\n"
+            "• Stil-Vorlagen & Auto-Erkennung\n"
+            "• Farbschema-Manager\n"
+            "• Drag & Drop\n"
+            "• Session-Verwaltung\n\n"
+            "© 2024 TU Bergakademie Freiberg"
+        )
+    
     # ========================================================================
-    # Session speichern/laden
+    # Session / Export
     # ========================================================================
-
+    
     def save_session(self):
-        """Speichert die aktuelle Session"""
         filepath = filedialog.asksaveasfilename(
             defaultextension=".json",
-            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            filetypes=[("JSON", "*.json")],
             title="Session speichern"
         )
-
+        
         if not filepath:
             return
-
+        
         try:
-            session_data = {
+            session = {
                 'groups': [g.to_dict() for g in self.groups],
-                'plot_settings': self.plot_settings,
-                'color_palette': self.color_palette
+                'unassigned': [d.to_dict() for d in self.unassigned_datasets],
+                'plot_type': self.current_plot_type,
+                'color_scheme': self.color_scheme,
+                'plot_settings': self.plot_settings
             }
-
+            
             with open(filepath, 'w', encoding='utf-8') as f:
-                json.dump(session_data, f, indent=2)
-
-            messagebox.showinfo("Erfolg", f"Session gespeichert in:\n{filepath}")
-
+                json.dump(session, f, indent=2)
+            
+            messagebox.showinfo("Erfolg", f"Session gespeichert:\n{filepath}")
         except Exception as e:
-            messagebox.showerror("Fehler", f"Fehler beim Speichern:\n{e}")
-
+            messagebox.showerror("Fehler", f"Fehler:\n{e}")
+    
     def load_session(self):
-        """Lädt eine gespeicherte Session"""
         filepath = filedialog.askopenfilename(
-            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            filetypes=[("JSON", "*.json")],
             title="Session laden"
         )
-
+        
         if not filepath:
             return
-
+        
         try:
             with open(filepath, 'r', encoding='utf-8') as f:
-                session_data = json.load(f)
-
-            # Alte Daten löschen
+                session = json.load(f)
+            
+            # Clear
             self.groups.clear()
+            self.unassigned_datasets.clear()
             for item in self.tree.get_children():
+                if item != self.unassigned_id:
+                    self.tree.delete(item)
+            for item in self.tree.get_children(self.unassigned_id):
                 self.tree.delete(item)
-
-            # Gruppen laden
-            for group_data in session_data.get('groups', []):
-                group = DataGroup.from_dict(group_data)
+            
+            # Load groups
+            for g_data in session.get('groups', []):
+                group = DataGroup.from_dict(g_data)
                 self.groups.append(group)
-
-                # In Tree einfügen
-                group_id = self.tree.insert("", tk.END, text=group.name,
-                                           values=(f"×{group.stack_factor}",),
-                                           tags=("group",))
-                self.tree.item(group_id, open=True)
-
-                for dataset in group.datasets:
-                    self.tree.insert(group_id, tk.END, text=dataset.display_label,
-                                   values=("",), tags=("dataset",))
-
-            # Einstellungen laden
-            if 'plot_settings' in session_data:
-                self.plot_settings.update(session_data['plot_settings'])
-
-            if 'color_palette' in session_data:
-                self.color_palette = session_data['color_palette']
-
+                
+                gid = self.tree.insert("", tk.END, text=group.name,
+                                      values=(f"×{group.stack_factor}",), tags=("group",))
+                self.tree.item(gid, open=True)
+                
+                for ds in group.datasets:
+                    self.tree.insert(gid, tk.END, text=ds.display_label, values=("",), tags=("dataset",))
+            
+            # Load unassigned
+            for d_data in session.get('unassigned', []):
+                ds = DataSet.from_dict(d_data)
+                self.unassigned_datasets.append(ds)
+                self.tree.insert(self.unassigned_id, tk.END, text=ds.display_label, values=("",), tags=("dataset",))
+            
+            # Settings
+            self.current_plot_type = session.get('plot_type', 'Log-Log')
+            self.plot_type_var.set(self.current_plot_type)
+            self.color_scheme = session.get('color_scheme', 'TUBAF')
+            self.color_scheme_var.set(self.color_scheme)
+            if 'plot_settings' in session:
+                self.plot_settings.update(session['plot_settings'])
+            
+            self.setup_plot_axes()
             self.update_plot()
             messagebox.showinfo("Erfolg", "Session geladen")
-
         except Exception as e:
-            messagebox.showerror("Fehler", f"Fehler beim Laden:\n{e}")
-
-    # ========================================================================
-    # Export-Funktionen
-    # ========================================================================
-
+            messagebox.showerror("Fehler", f"Fehler:\n{e}")
+    
     def export_png(self):
-        """Exportiert den Plot als PNG"""
         filepath = filedialog.asksaveasfilename(
             defaultextension=".png",
-            filetypes=[("PNG Dateien", "*.png"), ("Alle Dateien", "*.*")],
-            title="Als PNG exportieren"
+            filetypes=[("PNG", "*.png")],
+            title="PNG Export"
         )
-
+        
         if not filepath:
             return
-
-        # DPI abfragen
-        dpi = simpledialog.askinteger("Export DPI",
-                                      "DPI für Export (z.B. 300 für Publikation):",
-                                      initialvalue=self.plot_settings['export_dpi'],
-                                      minvalue=72,
-                                      maxvalue=1200)
+        
+        dpi = simpledialog.askinteger("DPI", "DPI:", initialvalue=self.config.get_export_dpi(),
+                                      minvalue=72, maxvalue=1200)
         if not dpi:
-            dpi = self.plot_settings['export_dpi']
-
+            dpi = 300
+        
         try:
             self.fig.savefig(filepath, dpi=dpi, bbox_inches='tight', facecolor='white')
-            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}\nDPI: {dpi}")
+            self.config.set_export_dpi(dpi)
+            messagebox.showinfo("Erfolg", f"Exportiert:\n{filepath}\nDPI: {dpi}")
         except Exception as e:
-            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
-
+            messagebox.showerror("Fehler", f"Fehler:\n{e}")
+    
     def export_svg(self):
-        """Exportiert den Plot als SVG"""
         filepath = filedialog.asksaveasfilename(
             defaultextension=".svg",
-            filetypes=[("SVG Dateien", "*.svg"), ("Alle Dateien", "*.*")],
-            title="Als SVG exportieren"
+            filetypes=[("SVG", "*.svg")],
+            title="SVG Export"
         )
-
+        
         if not filepath:
             return
-
+        
         try:
             self.fig.savefig(filepath, format='svg', bbox_inches='tight')
-            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}")
+            messagebox.showinfo("Erfolg", f"Exportiert:\n{filepath}")
         except Exception as e:
-            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
-
-    def show_about(self):
-        """Zeigt Über-Dialog"""
-        about_text = """TUBAF Scattering Plot Tool
-Version 2.0
-
-Entwickelt für die TU Bergakademie Freiberg
-
-Features:
-• Drag & Drop Gruppenzuordnung
-• Individuelle Farb- und Stil-Anpassung
-• PNG/SVG Export
-• Session speichern/laden
-• 4K Display-Unterstützung
-
-© 2024 TU Bergakademie Freiberg"""
-
-        messagebox.showinfo("Über", about_text)
+            messagebox.showerror("Fehler", f"Fehler:\n{e}")
 
 
 # ============================================================================
-# Dialog-Klassen
+# Dialoge
 # ============================================================================
 
 class StyleDialog:
-    """Dialog zum Ändern des Datensatz-Stils"""
-    def __init__(self, parent, dataset, update_callback):
+    """Stil-Dialog"""
+    def __init__(self, parent, dataset, callback):
         self.dataset = dataset
-        self.update_callback = update_callback
-
+        self.callback = callback
+        
         self.dialog = tk.Toplevel(parent)
-        self.dialog.title(f"Stil ändern: {dataset.display_label}")
-        self.dialog.geometry("400x350")
+        self.dialog.title(f"Stil: {dataset.display_label}")
+        self.dialog.geometry("400x300")
         self.dialog.transient(parent)
         self.dialog.grab_set()
-
-        # Linientyp
-        ttk.Label(self.dialog, text="Linientyp:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        
+        ttk.Label(self.dialog, text="Linie:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
         self.line_var = tk.StringVar(value=dataset.line_style or 'auto')
-        line_combo = ttk.Combobox(self.dialog, textvariable=self.line_var,
-                                   values=['auto', '-', '--', '-.', ':', ''], width=15)
-        line_combo.grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Markertyp
+        ttk.Combobox(self.dialog, textvariable=self.line_var,
+                     values=['auto', '-', '--', '-.', ':', ''], width=15).grid(row=0, column=1, padx=10, pady=5)
+        
         ttk.Label(self.dialog, text="Marker:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
         self.marker_var = tk.StringVar(value=dataset.marker_style or 'auto')
-        marker_combo = ttk.Combobox(self.dialog, textvariable=self.marker_var,
-                                     values=['auto', 'o', 's', '^', 'v', 'D', '*', '+', 'x', ''], width=15)
-        marker_combo.grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Linienbreite
+        ttk.Combobox(self.dialog, textvariable=self.marker_var,
+                     values=['auto', 'o', 's', '^', 'v', 'D', '*', '+', 'x', ''], width=15).grid(row=1, column=1, padx=10, pady=5)
+        
         ttk.Label(self.dialog, text="Linienbreite:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
-        self.linewidth_var = tk.DoubleVar(value=dataset.line_width)
+        self.lw_var = tk.DoubleVar(value=dataset.line_width)
         ttk.Spinbox(self.dialog, from_=0.5, to=10, increment=0.5,
-                    textvariable=self.linewidth_var, width=15).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Markergröße
+                    textvariable=self.lw_var, width=15).grid(row=2, column=1, padx=10, pady=5)
+        
         ttk.Label(self.dialog, text="Markergröße:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
-        self.markersize_var = tk.DoubleVar(value=dataset.marker_size)
-        ttk.Spinbox(self.dialog, from_=1, to=20, increment=1,
-                    textvariable=self.markersize_var, width=15).grid(row=3, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # In Legende anzeigen
+        self.ms_var = tk.DoubleVar(value=dataset.marker_size)
+        ttk.Spinbox(self.dialog, from_=1, to=20, textvariable=self.ms_var, width=15).grid(row=3, column=1, padx=10, pady=5)
+        
         ttk.Label(self.dialog, text="In Legende:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
         self.legend_var = tk.BooleanVar(value=dataset.show_in_legend)
-        ttk.Checkbutton(self.dialog, text="Anzeigen",
-                        variable=self.legend_var).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Buttons
-        button_frame = ttk.Frame(self.dialog)
-        button_frame.grid(row=5, column=0, columnspan=2, pady=20)
-
-        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
-        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
-
+        ttk.Checkbutton(self.dialog, text="Anzeigen", variable=self.legend_var).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
+        
+        btn_frame = ttk.Frame(self.dialog)
+        btn_frame.grid(row=5, column=0, columnspan=2, pady=20)
+        ttk.Button(btn_frame, text="OK", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+    
     def apply(self):
-        """Wendet die Änderungen an"""
-        line_val = self.line_var.get()
-        self.dataset.line_style = None if line_val == 'auto' else line_val
-
-        marker_val = self.marker_var.get()
-        self.dataset.marker_style = None if marker_val == 'auto' else marker_val
-
-        self.dataset.line_width = self.linewidth_var.get()
-        self.dataset.marker_size = self.markersize_var.get()
+        self.dataset.line_style = None if self.line_var.get() == 'auto' else self.line_var.get()
+        self.dataset.marker_style = None if self.marker_var.get() == 'auto' else self.marker_var.get()
+        self.dataset.line_width = self.lw_var.get()
+        self.dataset.marker_size = self.ms_var.get()
         self.dataset.show_in_legend = self.legend_var.get()
-
-        self.update_callback()
+        self.callback()
         self.dialog.destroy()
 
 
 class PlotSettingsDialog:
-    """Dialog für erweiterte Plot-Einstellungen"""
-    def __init__(self, parent, settings, update_callback):
+    """Plot-Einstellungen"""
+    def __init__(self, parent, settings, callback):
         self.settings = settings
-        self.update_callback = update_callback
-
+        self.callback = callback
+        
         self.dialog = tk.Toplevel(parent)
         self.dialog.title("Plot-Einstellungen")
-        self.dialog.geometry("500x450")
+        self.dialog.geometry("550x500")
         self.dialog.transient(parent)
         self.dialog.grab_set()
-
+        
+        row = 0
+        
         # X-Label
-        ttk.Label(self.dialog, text="X-Achsen Label:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        ttk.Label(self.dialog, text="X-Label:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
         self.xlabel_var = tk.StringVar(value=settings['xlabel'])
-        ttk.Entry(self.dialog, textvariable=self.xlabel_var, width=30).grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
-
+        ttk.Entry(self.dialog, textvariable=self.xlabel_var, width=30).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
         # Y-Label
-        ttk.Label(self.dialog, text="Y-Achsen Label:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
+        ttk.Label(self.dialog, text="Y-Label:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
         self.ylabel_var = tk.StringVar(value=settings['ylabel'])
-        ttk.Entry(self.dialog, textvariable=self.ylabel_var, width=30).grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
-
+        ttk.Entry(self.dialog, textvariable=self.ylabel_var, width=30).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        # X-Limits
+        ttk.Label(self.dialog, text="X-Limits:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
+        self.xlim_auto_var = tk.BooleanVar(value=settings['xlim_auto'])
+        ttk.Checkbutton(self.dialog, text="Auto", variable=self.xlim_auto_var).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        xlim_frame = ttk.Frame(self.dialog)
+        xlim_frame.grid(row=row, column=0, columnspan=2, padx=10, pady=5)
+        ttk.Label(xlim_frame, text="Min:").pack(side=tk.LEFT, padx=5)
+        self.xlim_min_var = tk.StringVar(value=str(settings['xlim'][0] or ''))
+        ttk.Entry(xlim_frame, textvariable=self.xlim_min_var, width=10).pack(side=tk.LEFT, padx=5)
+        ttk.Label(xlim_frame, text="Max:").pack(side=tk.LEFT, padx=5)
+        self.xlim_max_var = tk.StringVar(value=str(settings['xlim'][1] or ''))
+        ttk.Entry(xlim_frame, textvariable=self.xlim_max_var, width=10).pack(side=tk.LEFT, padx=5)
+        row += 1
+        
+        # Y-Limits
+        ttk.Label(self.dialog, text="Y-Limits:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
+        self.ylim_auto_var = tk.BooleanVar(value=settings['ylim_auto'])
+        ttk.Checkbutton(self.dialog, text="Auto", variable=self.ylim_auto_var).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        ylim_frame = ttk.Frame(self.dialog)
+        ylim_frame.grid(row=row, column=0, columnspan=2, padx=10, pady=5)
+        ttk.Label(ylim_frame, text="Min:").pack(side=tk.LEFT, padx=5)
+        self.ylim_min_var = tk.StringVar(value=str(settings['ylim'][0] or ''))
+        ttk.Entry(ylim_frame, textvariable=self.ylim_min_var, width=10).pack(side=tk.LEFT, padx=5)
+        ttk.Label(ylim_frame, text="Max:").pack(side=tk.LEFT, padx=5)
+        self.ylim_max_var = tk.StringVar(value=str(settings['ylim'][1] or ''))
+        ttk.Entry(ylim_frame, textvariable=self.ylim_max_var, width=10).pack(side=tk.LEFT, padx=5)
+        row += 1
+        
         # Grid
-        ttk.Label(self.dialog, text="Grid Modus:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
+        ttk.Label(self.dialog, text="Grid:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
         self.grid_which_var = tk.StringVar(value=settings['grid_which'])
         ttk.Combobox(self.dialog, textvariable=self.grid_which_var,
-                     values=['both', 'major', 'minor'], width=27).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Grid Alpha
-        ttk.Label(self.dialog, text="Grid Transparenz:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
-        self.grid_alpha_var = tk.DoubleVar(value=settings['grid_alpha'])
-        ttk.Scale(self.dialog, from_=0, to=1, variable=self.grid_alpha_var,
-                  orient=tk.HORIZONTAL).grid(row=3, column=1, sticky=tk.EW, padx=10, pady=5)
-
-        # Legenden-Schriftgröße
-        ttk.Label(self.dialog, text="Legenden-Schriftgröße:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
-        self.legend_fontsize_var = tk.IntVar(value=settings['legend_fontsize'])
-        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.legend_fontsize_var,
-                    width=27).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Achsen-Schriftgröße
-        ttk.Label(self.dialog, text="Achsen-Schriftgröße:").grid(row=5, column=0, sticky=tk.W, padx=10, pady=5)
-        self.axis_fontsize_var = tk.IntVar(value=settings['axis_fontsize'])
-        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.axis_fontsize_var,
-                    width=27).grid(row=5, column=1, sticky=tk.W, padx=10, pady=5)
-
-        # Export DPI
-        ttk.Label(self.dialog, text="Standard Export DPI:").grid(row=6, column=0, sticky=tk.W, padx=10, pady=5)
-        self.export_dpi_var = tk.IntVar(value=settings['export_dpi'])
-        ttk.Spinbox(self.dialog, from_=72, to=1200, increment=50,
-                    textvariable=self.export_dpi_var, width=27).grid(row=6, column=1, sticky=tk.W, padx=10, pady=5)
-
+                     values=['both', 'major', 'minor'], width=27).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        # Legende Position
+        ttk.Label(self.dialog, text="Legende:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_loc_var = tk.StringVar(value=settings['legend_loc'])
+        ttk.Combobox(self.dialog, textvariable=self.legend_loc_var,
+                     values=['best', 'upper right', 'upper left', 'lower right', 'lower left', 'center'], 
+                     width=27).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        # Schriftgrößen
+        ttk.Label(self.dialog, text="Legende-Schrift:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_fs_var = tk.IntVar(value=settings['legend_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.legend_fs_var, width=27).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
+        ttk.Label(self.dialog, text="Achsen-Schrift:").grid(row=row, column=0, sticky=tk.W, padx=10, pady=5)
+        self.axis_fs_var = tk.IntVar(value=settings['axis_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.axis_fs_var, width=27).grid(row=row, column=1, sticky=tk.W, padx=10, pady=5)
+        row += 1
+        
         # Buttons
-        button_frame = ttk.Frame(self.dialog)
-        button_frame.grid(row=7, column=0, columnspan=2, pady=20)
-
-        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
-        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
-
+        btn_frame = ttk.Frame(self.dialog)
+        btn_frame.grid(row=row, column=0, columnspan=2, pady=20)
+        ttk.Button(btn_frame, text="OK", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(btn_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+    
     def apply(self):
-        """Wendet die Änderungen an"""
         self.settings['xlabel'] = self.xlabel_var.get()
         self.settings['ylabel'] = self.ylabel_var.get()
+        
+        self.settings['xlim_auto'] = self.xlim_auto_var.get()
+        try:
+            xmin = float(self.xlim_min_var.get()) if self.xlim_min_var.get() else None
+            xmax = float(self.xlim_max_var.get()) if self.xlim_max_var.get() else None
+            self.settings['xlim'] = [xmin, xmax]
+        except:
+            pass
+        
+        self.settings['ylim_auto'] = self.ylim_auto_var.get()
+        try:
+            ymin = float(self.ylim_min_var.get()) if self.ylim_min_var.get() else None
+            ymax = float(self.ylim_max_var.get()) if self.ylim_max_var.get() else None
+            self.settings['ylim'] = [ymin, ymax]
+        except:
+            pass
+        
         self.settings['grid_which'] = self.grid_which_var.get()
-        self.settings['grid_alpha'] = self.grid_alpha_var.get()
-        self.settings['legend_fontsize'] = self.legend_fontsize_var.get()
-        self.settings['axis_fontsize'] = self.axis_fontsize_var.get()
-        self.settings['export_dpi'] = self.export_dpi_var.get()
-
-        self.update_callback()
+        self.settings['legend_loc'] = self.legend_loc_var.get()
+        self.settings['legend_fontsize'] = self.legend_fs_var.get()
+        self.settings['axis_fontsize'] = self.axis_fs_var.get()
+        
+        self.callback()
         self.dialog.destroy()
 
 
+class DesignManagerDialog:
+    """Design-Manager mit Tabs"""
+    def __init__(self, parent, config, callback):
+        self.config = config
+        self.callback = callback
+        
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Design-Manager")
+        self.dialog.geometry("700x600")
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+        
+        notebook = ttk.Notebook(self.dialog)
+        notebook.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        
+        # Tabs
+        self.create_styles_tab(notebook)
+        self.create_colors_tab(notebook)
+        self.create_autodetect_tab(notebook)
+        
+        # Buttons
+        btn_frame = ttk.Frame(self.dialog)
+        btn_frame.pack(fill=tk.X, padx=10, pady=10)
+        ttk.Button(btn_frame, text="Schließen", command=self.dialog.destroy).pack(side=tk.RIGHT, padx=5)
+    
+    def create_styles_tab(self, notebook):
+        """Stil-Vorlagen Tab"""
+        tab = ttk.Frame(notebook)
+        notebook.add(tab, text="Stil-Vorlagen")
+        
+        ttk.Label(tab, text="Verfügbare Stile:").pack(anchor=tk.W, padx=10, pady=5)
+        
+        # Listbox
+        list_frame = ttk.Frame(tab)
+        list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        
+        scroll = ttk.Scrollbar(list_frame)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        
+        self.styles_listbox = tk.Listbox(list_frame, yscrollcommand=scroll.set)
+        self.styles_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scroll.config(command=self.styles_listbox.yview)
+        
+        self.refresh_styles_list()
+        
+        # Buttons
+        btn_frame = ttk.Frame(tab)
+        btn_frame.pack(fill=tk.X, padx=10, pady=5)
+        ttk.Button(btn_frame, text="Neuer Stil...", command=self.create_new_style).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Löschen", command=self.delete_style).pack(side=tk.LEFT, padx=2)
+    
+    def create_colors_tab(self, notebook):
+        """Farbschemata Tab"""
+        tab = ttk.Frame(notebook)
+        notebook.add(tab, text="Farbschemata")
+        
+        ttk.Label(tab, text="Verfügbare Schemata:").pack(anchor=tk.W, padx=10, pady=5)
+        
+        # Listbox
+        list_frame = ttk.Frame(tab)
+        list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        
+        scroll = ttk.Scrollbar(list_frame)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        
+        self.colors_listbox = tk.Listbox(list_frame, yscrollcommand=scroll.set)
+        self.colors_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scroll.config(command=self.colors_listbox.yview)
+        
+        self.refresh_colors_list()
+        
+        # Buttons
+        btn_frame = ttk.Frame(tab)
+        btn_frame.pack(fill=tk.X, padx=10, pady=5)
+        ttk.Button(btn_frame, text="Neues Schema...", command=self.create_new_scheme).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Löschen", command=self.delete_scheme).pack(side=tk.LEFT, padx=2)
+    
+    def create_autodetect_tab(self, notebook):
+        """Auto-Erkennung Tab"""
+        tab = ttk.Frame(notebook)
+        notebook.add(tab, text="Auto-Erkennung")
+        
+        ttk.Label(tab, text="Keyword → Stil Zuordnung:").pack(anchor=tk.W, padx=10, pady=5)
+        
+        # Listbox
+        list_frame = ttk.Frame(tab)
+        list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
+        
+        scroll = ttk.Scrollbar(list_frame)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        
+        self.autodetect_listbox = tk.Listbox(list_frame, yscrollcommand=scroll.set)
+        self.autodetect_listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scroll.config(command=self.autodetect_listbox.yview)
+        
+        self.refresh_autodetect_list()
+        
+        # Aktivieren
+        self.autodetect_enabled_var = tk.BooleanVar(value=self.config.auto_detection_enabled)
+        ttk.Checkbutton(tab, text="Auto-Erkennung aktiviert",
+                        variable=self.autodetect_enabled_var,
+                        command=self.toggle_autodetect).pack(anchor=tk.W, padx=10, pady=5)
+        
+        # Buttons
+        btn_frame = ttk.Frame(tab)
+        btn_frame.pack(fill=tk.X, padx=10, pady=5)
+        ttk.Button(btn_frame, text="Neue Regel...", command=self.create_autodetect_rule).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Löschen", command=self.delete_autodetect_rule).pack(side=tk.LEFT, padx=2)
+    
+    def refresh_styles_list(self):
+        self.styles_listbox.delete(0, tk.END)
+        for name, style in self.config.style_presets.items():
+            desc = style.get('description', '')
+            self.styles_listbox.insert(tk.END, f"{name}: {desc}")
+    
+    def refresh_colors_list(self):
+        self.colors_listbox.delete(0, tk.END)
+        for name in sorted(self.config.color_schemes.keys()):
+            self.colors_listbox.insert(tk.END, name)
+    
+    def refresh_autodetect_list(self):
+        self.autodetect_listbox.delete(0, tk.END)
+        for keyword, style in self.config.auto_detection_rules.items():
+            self.autodetect_listbox.insert(tk.END, f"{keyword} → {style}")
+    
+    def create_new_style(self):
+        name = simpledialog.askstring("Neuer Stil", "Stil-Name:")
+        if not name:
+            return
+        
+        # Einfacher Dialog - könnte erweitert werden
+        style = {
+            'line_style': '-',
+            'marker_style': '',
+            'line_width': 2,
+            'marker_size': 4,
+            'description': 'Benutzerdefiniert'
+        }
+        
+        self.config.add_style_preset(name, style)
+        self.refresh_styles_list()
+        self.callback()
+    
+    def delete_style(self):
+        sel = self.styles_listbox.curselection()
+        if not sel:
+            return
+        
+        name = self.styles_listbox.get(sel[0]).split(':')[0]
+        if messagebox.askyesno("Löschen", f"Stil '{name}' löschen?"):
+            self.config.delete_style_preset(name)
+            self.refresh_styles_list()
+            self.callback()
+    
+    def create_new_scheme(self):
+        name = simpledialog.askstring("Neues Schema", "Schema-Name:")
+        if not name:
+            return
+        
+        # Vereinfacht: 5 Farben abfragen
+        colors = []
+        for i in range(5):
+            color = colorchooser.askcolor(title=f"Farbe {i+1}")
+            if color[1]:
+                colors.append(color[1])
+            else:
+                break
+        
+        if colors:
+            self.config.save_color_scheme(name, colors)
+            self.refresh_colors_list()
+            self.callback()
+    
+    def delete_scheme(self):
+        sel = self.colors_listbox.curselection()
+        if not sel:
+            return
+        
+        name = self.colors_listbox.get(sel[0])
+        if self.config.delete_color_scheme(name):
+            self.refresh_colors_list()
+            self.callback()
+        else:
+            messagebox.showinfo("Info", "Standard-Schemata können nicht gelöscht werden")
+    
+    def create_autodetect_rule(self):
+        keyword = simpledialog.askstring("Neues Keyword", "Keyword (z.B. 'fit'):")
+        if not keyword:
+            return
+        
+        styles = list(self.config.style_presets.keys())
+        style = simpledialog.askstring("Stil", f"Stil-Name (verfügbar: {', '.join(styles)}):")
+        if not style or style not in styles:
+            return
+        
+        self.config.auto_detection_rules[keyword.lower()] = style
+        self.config.save_config()
+        self.refresh_autodetect_list()
+    
+    def delete_autodetect_rule(self):
+        sel = self.autodetect_listbox.curselection()
+        if not sel:
+            return
+        
+        text = self.autodetect_listbox.get(sel[0])
+        keyword = text.split(' → ')[0]
+        
+        if keyword in self.config.auto_detection_rules:
+            del self.config.auto_detection_rules[keyword]
+            self.config.save_config()
+            self.refresh_autodetect_list()
+    
+    def toggle_autodetect(self):
+        self.config.auto_detection_enabled = self.autodetect_enabled_var.get()
+        self.config.save_config()
+
+
 # ============================================================================
-# Hauptfunktion
+# Main
 # ============================================================================
 
 def main():
-    """Hauptfunktion"""
-    # DPI Awareness aktivieren
     enable_dpi_awareness()
-
+    
     root = tk.Tk()
-
-    # Verbesserte DPI-Skalierung für Linux/X11
+    
     if platform.system() == 'Linux':
         try:
             dpi = root.winfo_fpixels('1i')
-            if dpi > 96:  # 4K oder High-DPI Display
-                scale_factor = dpi / 96
-                root.tk.call('tk', 'scaling', scale_factor)
+            if dpi > 96:
+                root.tk.call('tk', 'scaling', dpi / 96)
         except:
             pass
-
+    
     app = ScatterPlotApp(root)
     root.mainloop()
 

--- a/scatter_plot_v2.py
+++ b/scatter_plot_v2.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+"""
+Scattering Plot Tool für TUBAF
+Grafische Oberfläche zur Darstellung von Streukurven mit Gruppierung und gestackter Ansicht
+
+Features:
+- Drag & Drop für Gruppenzuordnung
+- Individuelle Farb-, Stil- und Label-Anpassung
+- PNG/SVG Export mit DPI-Einstellungen
+- Session speichern/laden
+- 4K DPI-Unterstützung
+"""
+
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox, simpledialog, colorchooser
+import matplotlib
+matplotlib.use('TkAgg')  # Backend für bessere Performance
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+from matplotlib.figure import Figure
+import numpy as np
+from pathlib import Path
+import json
+import platform
+import sys
+
+from data_loader import load_scattering_data
+
+# TUBAF Farben importieren
+try:
+    from tu_freiberg_colors import PRIMARY, SECONDARY, TERTIARY, get_profile_colors
+    # Standard-Farbpalette für Plots erstellen
+    DEFAULT_COLORS = [
+        PRIMARY['uniblau']['hex'],
+        SECONDARY['geo']['hex'],
+        SECONDARY['material']['hex'],
+        SECONDARY['energie']['hex'],
+        SECONDARY['umwelt']['hex'],
+        TERTIARY['orange_2']['hex'],
+        TERTIARY['gruen_3']['hex'],
+        TERTIARY['tuerkis_2']['hex'],
+        TERTIARY['rot_6']['hex'],
+        TERTIARY['blau_2']['hex'],
+    ]
+except ImportError:
+    # Fallback falls tu_freiberg_colors nicht verfügbar
+    DEFAULT_COLORS = ['#0069b4', '#8b7530', '#007b99', '#b71e3f', '#15882e',
+                      '#e18409', '#95c11f', '#1e959a', '#cd1222', '#a1d9ef']
+
+
+# ============================================================================
+# DPI Awareness für 4K Displays
+# ============================================================================
+
+def enable_dpi_awareness():
+    """Aktiviert DPI Awareness für scharfe Darstellung auf 4K Displays"""
+    try:
+        if platform.system() == 'Windows':
+            # Windows DPI Awareness
+            from ctypes import windll
+            windll.shcore.SetProcessDpiAwareness(1)
+        elif platform.system() == 'Linux':
+            # Linux/X11 DPI Scaling
+            pass  # Wird über Tk scalingFactor gehandhabt
+    except Exception as e:
+        print(f"DPI Awareness konnte nicht aktiviert werden: {e}")
+
+
+# ============================================================================
+# Datenklassen
+# ============================================================================
+
+class DataSet:
+    """Repräsentiert einen einzelnen Datensatz"""
+    def __init__(self, filepath, name=None):
+        self.filepath = Path(filepath)
+        self.name = name or self.filepath.stem
+        self.display_label = self.name  # Anzeigename (editierbar)
+        self.data = None
+        self.x = None
+        self.y = None
+        self.y_err = None
+
+        # Plot-Stil Einstellungen
+        self.line_style = None  # None = auto
+        self.marker_style = None  # None = auto
+        self.color = None  # None = Gruppenfarbe verwenden
+        self.line_width = 2
+        self.marker_size = 4
+        self.show_in_legend = True
+
+        self.load_data()
+
+    def load_data(self):
+        """Lädt die Daten aus der Datei"""
+        try:
+            self.data = load_scattering_data(self.filepath)
+            self.x = self.data[:, 0]
+            self.y = self.data[:, 1]
+            if self.data.shape[1] > 2:
+                self.y_err = self.data[:, 2]
+            else:
+                self.y_err = None
+        except Exception as e:
+            raise ValueError(f"Fehler beim Laden von {self.filepath}: {e}")
+
+    def get_plot_style(self):
+        """Gibt den Plot-Stil zurück (auto oder manuell gesetzt)"""
+        line_style = self.line_style
+        marker_style = self.marker_style
+
+        if line_style is None:
+            # Auto-Erkennung: Fits bekommen Linien, Messungen Punkte
+            line_style = '-' if 'fit' in self.name.lower() else ''
+
+        if marker_style is None:
+            marker_style = '' if 'fit' in self.name.lower() else 'o'
+
+        return line_style + marker_style
+
+    def to_dict(self):
+        """Serialisiert den Datensatz für Session-Speicherung"""
+        return {
+            'filepath': str(self.filepath),
+            'name': self.name,
+            'display_label': self.display_label,
+            'line_style': self.line_style,
+            'marker_style': self.marker_style,
+            'color': self.color,
+            'line_width': self.line_width,
+            'marker_size': self.marker_size,
+            'show_in_legend': self.show_in_legend
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        """Lädt Datensatz aus gespeicherten Daten"""
+        dataset = cls(data['filepath'], data.get('name'))
+        dataset.display_label = data.get('display_label', dataset.name)
+        dataset.line_style = data.get('line_style')
+        dataset.marker_style = data.get('marker_style')
+        dataset.color = data.get('color')
+        dataset.line_width = data.get('line_width', 2)
+        dataset.marker_size = data.get('marker_size', 4)
+        dataset.show_in_legend = data.get('show_in_legend', True)
+        return dataset
+
+
+class DataGroup:
+    """Repräsentiert eine Gruppe von Datensätzen"""
+    def __init__(self, name, stack_factor=1.0):
+        self.name = name
+        self.datasets = []
+        self.stack_factor = stack_factor
+        self.color = None  # None = Auto-Farbe
+        self.show_group_in_legend = True
+
+    def add_dataset(self, dataset):
+        """Fügt einen Datensatz zur Gruppe hinzu"""
+        self.datasets.append(dataset)
+
+    def remove_dataset(self, dataset):
+        """Entfernt einen Datensatz aus der Gruppe"""
+        if dataset in self.datasets:
+            self.datasets.remove(dataset)
+
+    def to_dict(self):
+        """Serialisiert die Gruppe für Session-Speicherung"""
+        return {
+            'name': self.name,
+            'stack_factor': self.stack_factor,
+            'color': self.color,
+            'show_group_in_legend': self.show_group_in_legend,
+            'datasets': [ds.to_dict() for ds in self.datasets]
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        """Lädt Gruppe aus gespeicherten Daten"""
+        group = cls(data['name'], data.get('stack_factor', 1.0))
+        group.color = data.get('color')
+        group.show_group_in_legend = data.get('show_group_in_legend', True)
+        for ds_data in data.get('datasets', []):
+            try:
+                dataset = DataSet.from_dict(ds_data)
+                group.add_dataset(dataset)
+            except Exception as e:
+                print(f"Fehler beim Laden von Datensatz: {e}")
+        return group
+
+
+# ============================================================================
+# Haupt-Anwendung
+# ============================================================================
+
+class ScatterPlotApp:
+    """Hauptanwendung für Scattering Plot Tool"""
+
+    def __init__(self, root):
+        self.root = root
+        self.root.title("TUBAF Scattering Plot Tool")
+        self.root.geometry("1600x1000")
+
+        # Datenverwaltung
+        self.groups = []
+        self.color_palette = DEFAULT_COLORS.copy()
+
+        # Plot-Einstellungen
+        self.plot_settings = {
+            'stack_mode': True,
+            'xlabel': 'q / nm⁻¹',
+            'ylabel': 'Intensität / a.u.',
+            'show_grid': True,
+            'grid_which': 'both',
+            'grid_alpha': 0.3,
+            'legend_fontsize': 10,
+            'axis_fontsize': 12,
+            'figure_dpi': 100,
+            'export_dpi': 300,
+        }
+
+        # Drag & Drop State
+        self.drag_data = None
+
+        # GUI erstellen
+        self.create_gui()
+        self.create_menu()
+
+    def create_menu(self):
+        """Erstellt die Menüleiste"""
+        menubar = tk.Menu(self.root)
+        self.root.config(menu=menubar)
+
+        # Datei-Menü
+        file_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Datei", menu=file_menu)
+        file_menu.add_command(label="Session speichern", command=self.save_session)
+        file_menu.add_command(label="Session laden", command=self.load_session)
+        file_menu.add_separator()
+        file_menu.add_command(label="Exportieren als PNG", command=self.export_png)
+        file_menu.add_command(label="Exportieren als SVG", command=self.export_svg)
+        file_menu.add_separator()
+        file_menu.add_command(label="Beenden", command=self.root.quit)
+
+        # Plot-Menü
+        plot_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Plot", menu=plot_menu)
+        plot_menu.add_command(label="Aktualisieren", command=self.update_plot)
+        plot_menu.add_command(label="Einstellungen", command=self.show_plot_settings)
+
+        # Hilfe-Menü
+        help_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Hilfe", menu=help_menu)
+        help_menu.add_command(label="Über", command=self.show_about)
+
+    def create_gui(self):
+        """Erstellt die grafische Benutzeroberfläche"""
+
+        # Hauptcontainer mit Paned Window
+        main_paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
+        main_paned.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        # Linke Seite: Datenverwaltung
+        left_frame = ttk.Frame(main_paned, width=450)
+        main_paned.add(left_frame, weight=1)
+
+        # Rechte Seite: Plot
+        right_frame = ttk.Frame(main_paned)
+        main_paned.add(right_frame, weight=3)
+
+        # === Linke Seite: Kontrollen ===
+
+        # Buttons für Datenverwaltung
+        button_frame = ttk.Frame(left_frame)
+        button_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ttk.Button(button_frame, text="➕ Neue Gruppe",
+                   command=self.create_group).pack(side=tk.LEFT, padx=2)
+        ttk.Button(button_frame, text="📁 Daten laden",
+                   command=self.load_data_simple).pack(side=tk.LEFT, padx=2)
+        ttk.Button(button_frame, text="🗑 Löschen",
+                   command=self.delete_selected).pack(side=tk.LEFT, padx=2)
+
+        # Treeview für Gruppen und Datensätze
+        tree_frame = ttk.Frame(left_frame)
+        tree_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        # Scrollbars
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL)
+        tree_scroll_y.pack(side=tk.RIGHT, fill=tk.Y)
+
+        self.tree = ttk.Treeview(tree_frame,
+                                  columns=("info",),
+                                  yscrollcommand=tree_scroll_y.set)
+        self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        tree_scroll_y.config(command=self.tree.yview)
+
+        self.tree.heading("#0", text="Name")
+        self.tree.heading("info", text="Info")
+        self.tree.column("info", width=100)
+
+        # Event-Bindings für Drag & Drop und Kontextmenü
+        self.tree.bind("<ButtonPress-1>", self.on_tree_press)
+        self.tree.bind("<B1-Motion>", self.on_tree_motion)
+        self.tree.bind("<ButtonRelease-1>", self.on_tree_release)
+        self.tree.bind("<Double-Button-1>", self.on_tree_double_click)
+        self.tree.bind("<Button-3>", self.show_context_menu)  # Rechtsklick
+
+        # Kontext-Menü erstellen
+        self.context_menu = tk.Menu(self.root, tearoff=0)
+        self.context_menu.add_command(label="Umbenennen", command=self.rename_item)
+        self.context_menu.add_command(label="Farbe ändern", command=self.change_color)
+        self.context_menu.add_command(label="Stil ändern", command=self.change_style)
+        self.context_menu.add_separator()
+        self.context_menu.add_command(label="Löschen", command=self.delete_selected)
+
+        # Schnell-Optionen
+        options_frame = ttk.LabelFrame(left_frame, text="Schnell-Optionen")
+        options_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ttk.Label(options_frame, text="Stack-Modus:").grid(row=0, column=0,
+                                                            sticky=tk.W, padx=5, pady=2)
+        self.stack_mode_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(options_frame, text="Aktiviert",
+                        variable=self.stack_mode_var,
+                        command=self.update_plot).grid(row=0, column=1,
+                                                        sticky=tk.W, padx=5, pady=2)
+
+        ttk.Label(options_frame, text="Grid:").grid(row=1, column=0,
+                                                     sticky=tk.W, padx=5, pady=2)
+        self.grid_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(options_frame, text="Anzeigen",
+                        variable=self.grid_var,
+                        command=self.update_plot).grid(row=1, column=1,
+                                                        sticky=tk.W, padx=5, pady=2)
+
+        options_frame.columnconfigure(1, weight=1)
+
+        # Plot-Button
+        plot_button_frame = ttk.Frame(left_frame)
+        plot_button_frame.pack(fill=tk.X, padx=5, pady=5)
+        ttk.Button(plot_button_frame, text="🔄 Plot aktualisieren",
+                   command=self.update_plot).pack(fill=tk.X)
+
+        # === Rechte Seite: Matplotlib Plot ===
+
+        self.fig = Figure(figsize=(12, 9), dpi=self.plot_settings['figure_dpi'])
+        self.ax = self.fig.add_subplot(111)
+
+        self.canvas = FigureCanvasTkAgg(self.fig, master=right_frame)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        # Matplotlib Toolbar
+        toolbar = NavigationToolbar2Tk(self.canvas, right_frame)
+        toolbar.update()
+
+        # Initial-Plot
+        self.update_plot()
+
+    # ========================================================================
+    # Drag & Drop Funktionalität
+    # ========================================================================
+
+    def on_tree_press(self, event):
+        """Start von Drag & Drop"""
+        item = self.tree.identify_row(event.y)
+        if item:
+            self.drag_data = {'item': item, 'start_y': event.y}
+
+    def on_tree_motion(self, event):
+        """Während Drag & Drop"""
+        if self.drag_data and abs(event.y - self.drag_data['start_y']) > 5:
+            # Cursor ändern um Drag zu signalisieren
+            self.tree.config(cursor="hand2")
+
+    def on_tree_release(self, event):
+        """Ende von Drag & Drop"""
+        if self.drag_data:
+            source_item = self.drag_data['item']
+            target_item = self.tree.identify_row(event.y)
+
+            if target_item and source_item != target_item:
+                # Prüfen ob Datensatz auf Gruppe gedroppt wird
+                source_parent = self.tree.parent(source_item)
+                target_parent = self.tree.parent(target_item)
+
+                # Datensatz wird auf Gruppe gedroppt
+                if source_parent and not target_parent:
+                    self.move_dataset_to_group(source_item, target_item)
+                # Datensatz wird auf Datensatz gedroppt (zur gleichen Gruppe)
+                elif source_parent and target_parent:
+                    self.move_dataset_to_group(source_item, target_parent)
+
+            self.tree.config(cursor="")
+            self.drag_data = None
+
+    def move_dataset_to_group(self, dataset_item, target_group_item):
+        """Verschiebt einen Datensatz in eine andere Gruppe"""
+        # Namen ermitteln
+        dataset_name = self.tree.item(dataset_item, 'text')
+        source_group_name = self.tree.item(self.tree.parent(dataset_item), 'text')
+        target_group_name = self.tree.item(target_group_item, 'text')
+
+        if source_group_name == target_group_name:
+            return  # Gleiche Gruppe
+
+        # Datensatz und Gruppen finden
+        source_group = next((g for g in self.groups if g.name == source_group_name), None)
+        target_group = next((g for g in self.groups if g.name == target_group_name), None)
+
+        if source_group and target_group:
+            dataset = next((d for d in source_group.datasets if d.name == dataset_name), None)
+            if dataset:
+                # Verschieben
+                source_group.remove_dataset(dataset)
+                target_group.add_dataset(dataset)
+
+                # Tree aktualisieren
+                self.tree.delete(dataset_item)
+                self.tree.insert(target_group_item, tk.END, text=dataset.display_label,
+                               values=("",), tags=("dataset",))
+
+                self.update_plot()
+
+    # ========================================================================
+    # Kontextmenü und Bearbeitungs-Funktionen
+    # ========================================================================
+
+    def show_context_menu(self, event):
+        """Zeigt Kontextmenü bei Rechtsklick"""
+        item = self.tree.identify_row(event.y)
+        if item:
+            self.tree.selection_set(item)
+            self.context_menu.post(event.x_root, event.y_root)
+
+    def on_tree_double_click(self, event):
+        """Doppelklick zum schnellen Bearbeiten"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        parent = self.tree.parent(item)
+
+        if not parent:  # Gruppe
+            self.edit_stack_factor(item)
+        else:  # Datensatz
+            self.rename_item()
+
+    def rename_item(self):
+        """Benennt Gruppe oder Datensatz um"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        item_text = self.tree.item(item, 'text')
+        parent = self.tree.parent(item)
+
+        new_name = simpledialog.askstring("Umbenennen", "Neuer Name:", initialvalue=item_text)
+        if not new_name:
+            return
+
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group:
+                group.name = new_name
+                self.tree.item(item, text=new_name)
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset:
+                    dataset.display_label = new_name
+                    self.tree.item(item, text=new_name)
+
+        self.update_plot()
+
+    def change_color(self):
+        """Ändert die Farbe einer Gruppe oder eines Datensatzes"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        item_text = self.tree.item(item, 'text')
+        parent = self.tree.parent(item)
+
+        # Aktuelle Farbe ermitteln
+        current_color = '#0069b4'
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group and group.color:
+                current_color = group.color
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset and dataset.color:
+                    current_color = dataset.color
+
+        # Farbauswahl-Dialog
+        color = colorchooser.askcolor(color=current_color, title="Farbe wählen")
+        if not color[1]:
+            return
+
+        new_color = color[1]
+
+        # Farbe setzen
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group:
+                group.color = new_color
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset:
+                    dataset.color = new_color
+
+        self.update_plot()
+
+    def change_style(self):
+        """Ändert den Stil eines Datensatzes (Linientyp, Marker)"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        parent = self.tree.parent(item)
+
+        if not parent:
+            messagebox.showinfo("Info", "Stil kann nur für Datensätze geändert werden")
+            return
+
+        item_text = self.tree.item(item, 'text')
+        parent_name = self.tree.item(parent, 'text')
+        group = next((g for g in self.groups if g.name == parent_name), None)
+
+        if not group:
+            return
+
+        dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+        if not dataset:
+            return
+
+        # Dialog für Stil-Einstellungen
+        StyleDialog(self.root, dataset, self.update_plot)
+
+    def edit_stack_factor(self, item=None):
+        """Bearbeitet den Stack-Faktor einer Gruppe"""
+        if item is None:
+            selected = self.tree.selection()
+            if not selected:
+                return
+            item = selected[0]
+
+        parent = self.tree.parent(item)
+        if parent:  # Nur für Gruppen
+            return
+
+        item_text = self.tree.item(item, 'text')
+        group = next((g for g in self.groups if g.name == item_text), None)
+
+        if group:
+            new_factor = simpledialog.askfloat("Stack-Faktor bearbeiten",
+                                                f"Neuer Stack-Faktor für '{group.name}':",
+                                                initialvalue=group.stack_factor)
+            if new_factor is not None:
+                group.stack_factor = new_factor
+                self.tree.item(item, values=(f"×{new_factor}",))
+                self.update_plot()
+
+    # ========================================================================
+    # Daten laden und verwalten
+    # ========================================================================
+
+    def create_group(self):
+        """Erstellt eine neue Gruppe"""
+        name = simpledialog.askstring("Neue Gruppe", "Gruppenname:")
+        if not name:
+            return
+
+        stack_factor = simpledialog.askfloat("Stack-Faktor",
+                                              "Stack-Faktor (z.B. 1, 10, 100):",
+                                              initialvalue=1.0)
+        if stack_factor is None:
+            stack_factor = 1.0
+
+        group = DataGroup(name, stack_factor)
+        self.groups.append(group)
+
+        # In Treeview einfügen
+        group_id = self.tree.insert("", tk.END, text=name,
+                                    values=(f"×{stack_factor}",),
+                                    tags=("group",))
+        self.tree.item(group_id, open=True)
+
+    def load_data_simple(self):
+        """Einfaches Laden von Daten - Dateien wählen, dann Gruppe zuordnen"""
+        # Dateien auswählen
+        filepaths = filedialog.askopenfilenames(
+            title="Datensätze auswählen",
+            filetypes=[("Alle Dateien", "*.*"),
+                       ("Text-Dateien", "*.txt"),
+                       ("CSV-Dateien", "*.csv"),
+                       ("DAT-Dateien", "*.dat")]
+        )
+
+        if not filepaths:
+            return
+
+        # Falls keine Gruppen vorhanden, eine erstellen
+        if not self.groups:
+            self.create_group()
+            if not self.groups:  # Benutzer hat abgebrochen
+                return
+
+        # Gruppe auswählen
+        group_names = [g.name for g in self.groups]
+        if len(group_names) == 1:
+            group_name = group_names[0]
+        else:
+            group_name = simpledialog.askstring("Gruppe wählen",
+                                                f"Gruppenname (verfügbar: {', '.join(group_names)}):")
+
+        group = next((g for g in self.groups if g.name == group_name), None)
+        if not group:
+            messagebox.showerror("Fehler", f"Gruppe '{group_name}' nicht gefunden")
+            return
+
+        # Dateien laden
+        for filepath in filepaths:
+            try:
+                dataset = DataSet(filepath)
+                group.add_dataset(dataset)
+
+                # In Treeview einfügen
+                for item in self.tree.get_children():
+                    if self.tree.item(item, "text") == group.name:
+                        self.tree.insert(item, tk.END, text=dataset.display_label,
+                                        values=("",), tags=("dataset",))
+                        break
+
+            except Exception as e:
+                messagebox.showerror("Fehler", f"Fehler beim Laden von {filepath}:\n{e}")
+
+        self.update_plot()
+
+    def delete_selected(self):
+        """Löscht ausgewählte Gruppe oder Datensatz"""
+        selected = self.tree.selection()
+        if not selected:
+            messagebox.showwarning("Keine Auswahl", "Bitte wählen Sie ein Element aus")
+            return
+
+        for item in selected:
+            item_text = self.tree.item(item, "text")
+            parent = self.tree.parent(item)
+
+            if not parent:  # Gruppe
+                group = next((g for g in self.groups if g.name == item_text), None)
+                if group:
+                    self.groups.remove(group)
+            else:  # Datensatz
+                parent_text = self.tree.item(parent, "text")
+                group = next((g for g in self.groups if g.name == parent_text), None)
+                if group:
+                    dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                    if dataset:
+                        group.remove_dataset(dataset)
+
+            self.tree.delete(item)
+
+        self.update_plot()
+
+    # ========================================================================
+    # Plot-Funktionen
+    # ========================================================================
+
+    def update_plot(self):
+        """Aktualisiert den Plot mit allen Gruppen und Datensätzen"""
+        self.ax.clear()
+
+        if not self.groups:
+            self.ax.text(0.5, 0.5, "Keine Daten geladen\n\nDateien per Drag & Drop oder '📁 Daten laden'",
+                        ha='center', va='center', transform=self.ax.transAxes,
+                        fontsize=14, color='gray')
+            self.canvas.draw()
+            return
+
+        # Farbpalette vorbereiten
+        colors = self.color_palette.copy()
+
+        stack_mode = self.stack_mode_var.get()
+
+        # Plot jede Gruppe
+        for group_idx, group in enumerate(self.groups):
+            if not group.datasets:
+                continue
+
+            # Farbe für die Gruppe
+            group_color = group.color if group.color else colors[group_idx % len(colors)]
+
+            # Stack-Faktor
+            stack_factor = group.stack_factor if stack_mode else 1.0
+
+            # Plot jeden Datensatz in der Gruppe
+            for ds_idx, dataset in enumerate(group.datasets):
+                if dataset.x is None or dataset.y is None:
+                    continue
+
+                # Y-Werte mit Stack-Faktor
+                y_plot = dataset.y * stack_factor
+
+                # Farbe: Datensatz-Farbe oder Gruppenfarbe
+                plot_color = dataset.color if dataset.color else group_color
+
+                # Label
+                if dataset.show_in_legend:
+                    if stack_mode and ds_idx == 0:
+                        label = f"{group.name} (×{stack_factor}) - {dataset.display_label}"
+                    else:
+                        label = f"{group.name} - {dataset.display_label}"
+                else:
+                    label = None
+
+                # Plot-Stil
+                plot_style = dataset.get_plot_style()
+
+                # Hauptplot
+                self.ax.plot(dataset.x, y_plot, plot_style,
+                           color=plot_color,
+                           linewidth=dataset.line_width,
+                           markersize=dataset.marker_size,
+                           label=label,
+                           alpha=0.8)
+
+                # Fehlerbereich
+                if dataset.y_err is not None:
+                    y_err_plot = dataset.y_err * stack_factor
+                    self.ax.fill_between(dataset.x,
+                                        y_plot - y_err_plot,
+                                        y_plot + y_err_plot,
+                                        color=plot_color,
+                                        alpha=0.2)
+
+        # Achsen-Einstellungen
+        self.ax.set_xscale('log')
+        self.ax.set_yscale('log')
+        self.ax.set_xlabel(self.plot_settings['xlabel'],
+                          fontsize=self.plot_settings['axis_fontsize'])
+        self.ax.set_ylabel(self.plot_settings['ylabel'],
+                          fontsize=self.plot_settings['axis_fontsize'])
+
+        if self.grid_var.get():
+            self.ax.grid(True,
+                        alpha=self.plot_settings['grid_alpha'],
+                        which=self.plot_settings['grid_which'])
+
+        self.ax.legend(fontsize=self.plot_settings['legend_fontsize'],
+                      framealpha=0.9)
+
+        self.fig.tight_layout()
+        self.canvas.draw()
+
+    def show_plot_settings(self):
+        """Zeigt Dialog für erweiterte Plot-Einstellungen"""
+        PlotSettingsDialog(self.root, self.plot_settings, self.update_plot)
+
+    # ========================================================================
+    # Session speichern/laden
+    # ========================================================================
+
+    def save_session(self):
+        """Speichert die aktuelle Session"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            title="Session speichern"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            session_data = {
+                'groups': [g.to_dict() for g in self.groups],
+                'plot_settings': self.plot_settings,
+                'color_palette': self.color_palette
+            }
+
+            with open(filepath, 'w', encoding='utf-8') as f:
+                json.dump(session_data, f, indent=2)
+
+            messagebox.showinfo("Erfolg", f"Session gespeichert in:\n{filepath}")
+
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Speichern:\n{e}")
+
+    def load_session(self):
+        """Lädt eine gespeicherte Session"""
+        filepath = filedialog.askopenfilename(
+            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            title="Session laden"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                session_data = json.load(f)
+
+            # Alte Daten löschen
+            self.groups.clear()
+            for item in self.tree.get_children():
+                self.tree.delete(item)
+
+            # Gruppen laden
+            for group_data in session_data.get('groups', []):
+                group = DataGroup.from_dict(group_data)
+                self.groups.append(group)
+
+                # In Tree einfügen
+                group_id = self.tree.insert("", tk.END, text=group.name,
+                                           values=(f"×{group.stack_factor}",),
+                                           tags=("group",))
+                self.tree.item(group_id, open=True)
+
+                for dataset in group.datasets:
+                    self.tree.insert(group_id, tk.END, text=dataset.display_label,
+                                   values=("",), tags=("dataset",))
+
+            # Einstellungen laden
+            if 'plot_settings' in session_data:
+                self.plot_settings.update(session_data['plot_settings'])
+
+            if 'color_palette' in session_data:
+                self.color_palette = session_data['color_palette']
+
+            self.update_plot()
+            messagebox.showinfo("Erfolg", "Session geladen")
+
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Laden:\n{e}")
+
+    # ========================================================================
+    # Export-Funktionen
+    # ========================================================================
+
+    def export_png(self):
+        """Exportiert den Plot als PNG"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".png",
+            filetypes=[("PNG Dateien", "*.png"), ("Alle Dateien", "*.*")],
+            title="Als PNG exportieren"
+        )
+
+        if not filepath:
+            return
+
+        # DPI abfragen
+        dpi = simpledialog.askinteger("Export DPI",
+                                      "DPI für Export (z.B. 300 für Publikation):",
+                                      initialvalue=self.plot_settings['export_dpi'],
+                                      minvalue=72,
+                                      maxvalue=1200)
+        if not dpi:
+            dpi = self.plot_settings['export_dpi']
+
+        try:
+            self.fig.savefig(filepath, dpi=dpi, bbox_inches='tight', facecolor='white')
+            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}\nDPI: {dpi}")
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
+
+    def export_svg(self):
+        """Exportiert den Plot als SVG"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".svg",
+            filetypes=[("SVG Dateien", "*.svg"), ("Alle Dateien", "*.*")],
+            title="Als SVG exportieren"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            self.fig.savefig(filepath, format='svg', bbox_inches='tight')
+            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}")
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
+
+    def show_about(self):
+        """Zeigt Über-Dialog"""
+        about_text = """TUBAF Scattering Plot Tool
+Version 2.0
+
+Entwickelt für die TU Bergakademie Freiberg
+
+Features:
+• Drag & Drop Gruppenzuordnung
+• Individuelle Farb- und Stil-Anpassung
+• PNG/SVG Export
+• Session speichern/laden
+• 4K Display-Unterstützung
+
+© 2024 TU Bergakademie Freiberg"""
+
+        messagebox.showinfo("Über", about_text)
+
+
+# ============================================================================
+# Dialog-Klassen
+# ============================================================================
+
+class StyleDialog:
+    """Dialog zum Ändern des Datensatz-Stils"""
+    def __init__(self, parent, dataset, update_callback):
+        self.dataset = dataset
+        self.update_callback = update_callback
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title(f"Stil ändern: {dataset.display_label}")
+        self.dialog.geometry("400x350")
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+
+        # Linientyp
+        ttk.Label(self.dialog, text="Linientyp:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        self.line_var = tk.StringVar(value=dataset.line_style or 'auto')
+        line_combo = ttk.Combobox(self.dialog, textvariable=self.line_var,
+                                   values=['auto', '-', '--', '-.', ':', ''], width=15)
+        line_combo.grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Markertyp
+        ttk.Label(self.dialog, text="Marker:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
+        self.marker_var = tk.StringVar(value=dataset.marker_style or 'auto')
+        marker_combo = ttk.Combobox(self.dialog, textvariable=self.marker_var,
+                                     values=['auto', 'o', 's', '^', 'v', 'D', '*', '+', 'x', ''], width=15)
+        marker_combo.grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Linienbreite
+        ttk.Label(self.dialog, text="Linienbreite:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
+        self.linewidth_var = tk.DoubleVar(value=dataset.line_width)
+        ttk.Spinbox(self.dialog, from_=0.5, to=10, increment=0.5,
+                    textvariable=self.linewidth_var, width=15).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Markergröße
+        ttk.Label(self.dialog, text="Markergröße:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
+        self.markersize_var = tk.DoubleVar(value=dataset.marker_size)
+        ttk.Spinbox(self.dialog, from_=1, to=20, increment=1,
+                    textvariable=self.markersize_var, width=15).grid(row=3, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # In Legende anzeigen
+        ttk.Label(self.dialog, text="In Legende:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_var = tk.BooleanVar(value=dataset.show_in_legend)
+        ttk.Checkbutton(self.dialog, text="Anzeigen",
+                        variable=self.legend_var).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Buttons
+        button_frame = ttk.Frame(self.dialog)
+        button_frame.grid(row=5, column=0, columnspan=2, pady=20)
+
+        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+
+    def apply(self):
+        """Wendet die Änderungen an"""
+        line_val = self.line_var.get()
+        self.dataset.line_style = None if line_val == 'auto' else line_val
+
+        marker_val = self.marker_var.get()
+        self.dataset.marker_style = None if marker_val == 'auto' else marker_val
+
+        self.dataset.line_width = self.linewidth_var.get()
+        self.dataset.marker_size = self.markersize_var.get()
+        self.dataset.show_in_legend = self.legend_var.get()
+
+        self.update_callback()
+        self.dialog.destroy()
+
+
+class PlotSettingsDialog:
+    """Dialog für erweiterte Plot-Einstellungen"""
+    def __init__(self, parent, settings, update_callback):
+        self.settings = settings
+        self.update_callback = update_callback
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Plot-Einstellungen")
+        self.dialog.geometry("500x450")
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+
+        # X-Label
+        ttk.Label(self.dialog, text="X-Achsen Label:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        self.xlabel_var = tk.StringVar(value=settings['xlabel'])
+        ttk.Entry(self.dialog, textvariable=self.xlabel_var, width=30).grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Y-Label
+        ttk.Label(self.dialog, text="Y-Achsen Label:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
+        self.ylabel_var = tk.StringVar(value=settings['ylabel'])
+        ttk.Entry(self.dialog, textvariable=self.ylabel_var, width=30).grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Grid
+        ttk.Label(self.dialog, text="Grid Modus:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
+        self.grid_which_var = tk.StringVar(value=settings['grid_which'])
+        ttk.Combobox(self.dialog, textvariable=self.grid_which_var,
+                     values=['both', 'major', 'minor'], width=27).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Grid Alpha
+        ttk.Label(self.dialog, text="Grid Transparenz:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
+        self.grid_alpha_var = tk.DoubleVar(value=settings['grid_alpha'])
+        ttk.Scale(self.dialog, from_=0, to=1, variable=self.grid_alpha_var,
+                  orient=tk.HORIZONTAL).grid(row=3, column=1, sticky=tk.EW, padx=10, pady=5)
+
+        # Legenden-Schriftgröße
+        ttk.Label(self.dialog, text="Legenden-Schriftgröße:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_fontsize_var = tk.IntVar(value=settings['legend_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.legend_fontsize_var,
+                    width=27).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Achsen-Schriftgröße
+        ttk.Label(self.dialog, text="Achsen-Schriftgröße:").grid(row=5, column=0, sticky=tk.W, padx=10, pady=5)
+        self.axis_fontsize_var = tk.IntVar(value=settings['axis_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.axis_fontsize_var,
+                    width=27).grid(row=5, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Export DPI
+        ttk.Label(self.dialog, text="Standard Export DPI:").grid(row=6, column=0, sticky=tk.W, padx=10, pady=5)
+        self.export_dpi_var = tk.IntVar(value=settings['export_dpi'])
+        ttk.Spinbox(self.dialog, from_=72, to=1200, increment=50,
+                    textvariable=self.export_dpi_var, width=27).grid(row=6, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Buttons
+        button_frame = ttk.Frame(self.dialog)
+        button_frame.grid(row=7, column=0, columnspan=2, pady=20)
+
+        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+
+    def apply(self):
+        """Wendet die Änderungen an"""
+        self.settings['xlabel'] = self.xlabel_var.get()
+        self.settings['ylabel'] = self.ylabel_var.get()
+        self.settings['grid_which'] = self.grid_which_var.get()
+        self.settings['grid_alpha'] = self.grid_alpha_var.get()
+        self.settings['legend_fontsize'] = self.legend_fontsize_var.get()
+        self.settings['axis_fontsize'] = self.axis_fontsize_var.get()
+        self.settings['export_dpi'] = self.export_dpi_var.get()
+
+        self.update_callback()
+        self.dialog.destroy()
+
+
+# ============================================================================
+# Hauptfunktion
+# ============================================================================
+
+def main():
+    """Hauptfunktion"""
+    # DPI Awareness aktivieren
+    enable_dpi_awareness()
+
+    root = tk.Tk()
+
+    # Verbesserte DPI-Skalierung für Linux/X11
+    if platform.system() == 'Linux':
+        try:
+            dpi = root.winfo_fpixels('1i')
+            if dpi > 96:  # 4K oder High-DPI Display
+                scale_factor = dpi / 96
+                root.tk.call('tk', 'scaling', scale_factor)
+        except:
+            pass
+
+    app = ScatterPlotApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/scatter_plot_v2_backup.py
+++ b/scatter_plot_v2_backup.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+"""
+Scattering Plot Tool für TUBAF
+Grafische Oberfläche zur Darstellung von Streukurven mit Gruppierung und gestackter Ansicht
+
+Features:
+- Drag & Drop für Gruppenzuordnung
+- Individuelle Farb-, Stil- und Label-Anpassung
+- PNG/SVG Export mit DPI-Einstellungen
+- Session speichern/laden
+- 4K DPI-Unterstützung
+"""
+
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox, simpledialog, colorchooser
+import matplotlib
+matplotlib.use('TkAgg')  # Backend für bessere Performance
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+from matplotlib.figure import Figure
+import numpy as np
+from pathlib import Path
+import json
+import platform
+import sys
+
+from data_loader import load_scattering_data
+
+# TUBAF Farben importieren
+try:
+    from tu_freiberg_colors import PRIMARY, SECONDARY, TERTIARY, get_profile_colors
+    # Standard-Farbpalette für Plots erstellen
+    DEFAULT_COLORS = [
+        PRIMARY['uniblau']['hex'],
+        SECONDARY['geo']['hex'],
+        SECONDARY['material']['hex'],
+        SECONDARY['energie']['hex'],
+        SECONDARY['umwelt']['hex'],
+        TERTIARY['orange_2']['hex'],
+        TERTIARY['gruen_3']['hex'],
+        TERTIARY['tuerkis_2']['hex'],
+        TERTIARY['rot_6']['hex'],
+        TERTIARY['blau_2']['hex'],
+    ]
+except ImportError:
+    # Fallback falls tu_freiberg_colors nicht verfügbar
+    DEFAULT_COLORS = ['#0069b4', '#8b7530', '#007b99', '#b71e3f', '#15882e',
+                      '#e18409', '#95c11f', '#1e959a', '#cd1222', '#a1d9ef']
+
+
+# ============================================================================
+# DPI Awareness für 4K Displays
+# ============================================================================
+
+def enable_dpi_awareness():
+    """Aktiviert DPI Awareness für scharfe Darstellung auf 4K Displays"""
+    try:
+        if platform.system() == 'Windows':
+            # Windows DPI Awareness
+            from ctypes import windll
+            windll.shcore.SetProcessDpiAwareness(1)
+        elif platform.system() == 'Linux':
+            # Linux/X11 DPI Scaling
+            pass  # Wird über Tk scalingFactor gehandhabt
+    except Exception as e:
+        print(f"DPI Awareness konnte nicht aktiviert werden: {e}")
+
+
+# ============================================================================
+# Datenklassen
+# ============================================================================
+
+class DataSet:
+    """Repräsentiert einen einzelnen Datensatz"""
+    def __init__(self, filepath, name=None):
+        self.filepath = Path(filepath)
+        self.name = name or self.filepath.stem
+        self.display_label = self.name  # Anzeigename (editierbar)
+        self.data = None
+        self.x = None
+        self.y = None
+        self.y_err = None
+
+        # Plot-Stil Einstellungen
+        self.line_style = None  # None = auto
+        self.marker_style = None  # None = auto
+        self.color = None  # None = Gruppenfarbe verwenden
+        self.line_width = 2
+        self.marker_size = 4
+        self.show_in_legend = True
+
+        self.load_data()
+
+    def load_data(self):
+        """Lädt die Daten aus der Datei"""
+        try:
+            self.data = load_scattering_data(self.filepath)
+            self.x = self.data[:, 0]
+            self.y = self.data[:, 1]
+            if self.data.shape[1] > 2:
+                self.y_err = self.data[:, 2]
+            else:
+                self.y_err = None
+        except Exception as e:
+            raise ValueError(f"Fehler beim Laden von {self.filepath}: {e}")
+
+    def get_plot_style(self):
+        """Gibt den Plot-Stil zurück (auto oder manuell gesetzt)"""
+        line_style = self.line_style
+        marker_style = self.marker_style
+
+        if line_style is None:
+            # Auto-Erkennung: Fits bekommen Linien, Messungen Punkte
+            line_style = '-' if 'fit' in self.name.lower() else ''
+
+        if marker_style is None:
+            marker_style = '' if 'fit' in self.name.lower() else 'o'
+
+        return line_style + marker_style
+
+    def to_dict(self):
+        """Serialisiert den Datensatz für Session-Speicherung"""
+        return {
+            'filepath': str(self.filepath),
+            'name': self.name,
+            'display_label': self.display_label,
+            'line_style': self.line_style,
+            'marker_style': self.marker_style,
+            'color': self.color,
+            'line_width': self.line_width,
+            'marker_size': self.marker_size,
+            'show_in_legend': self.show_in_legend
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        """Lädt Datensatz aus gespeicherten Daten"""
+        dataset = cls(data['filepath'], data.get('name'))
+        dataset.display_label = data.get('display_label', dataset.name)
+        dataset.line_style = data.get('line_style')
+        dataset.marker_style = data.get('marker_style')
+        dataset.color = data.get('color')
+        dataset.line_width = data.get('line_width', 2)
+        dataset.marker_size = data.get('marker_size', 4)
+        dataset.show_in_legend = data.get('show_in_legend', True)
+        return dataset
+
+
+class DataGroup:
+    """Repräsentiert eine Gruppe von Datensätzen"""
+    def __init__(self, name, stack_factor=1.0):
+        self.name = name
+        self.datasets = []
+        self.stack_factor = stack_factor
+        self.color = None  # None = Auto-Farbe
+        self.show_group_in_legend = True
+
+    def add_dataset(self, dataset):
+        """Fügt einen Datensatz zur Gruppe hinzu"""
+        self.datasets.append(dataset)
+
+    def remove_dataset(self, dataset):
+        """Entfernt einen Datensatz aus der Gruppe"""
+        if dataset in self.datasets:
+            self.datasets.remove(dataset)
+
+    def to_dict(self):
+        """Serialisiert die Gruppe für Session-Speicherung"""
+        return {
+            'name': self.name,
+            'stack_factor': self.stack_factor,
+            'color': self.color,
+            'show_group_in_legend': self.show_group_in_legend,
+            'datasets': [ds.to_dict() for ds in self.datasets]
+        }
+
+    @classmethod
+    def from_dict(cls, data):
+        """Lädt Gruppe aus gespeicherten Daten"""
+        group = cls(data['name'], data.get('stack_factor', 1.0))
+        group.color = data.get('color')
+        group.show_group_in_legend = data.get('show_group_in_legend', True)
+        for ds_data in data.get('datasets', []):
+            try:
+                dataset = DataSet.from_dict(ds_data)
+                group.add_dataset(dataset)
+            except Exception as e:
+                print(f"Fehler beim Laden von Datensatz: {e}")
+        return group
+
+
+# ============================================================================
+# Haupt-Anwendung
+# ============================================================================
+
+class ScatterPlotApp:
+    """Hauptanwendung für Scattering Plot Tool"""
+
+    def __init__(self, root):
+        self.root = root
+        self.root.title("TUBAF Scattering Plot Tool")
+        self.root.geometry("1600x1000")
+
+        # Datenverwaltung
+        self.groups = []
+        self.color_palette = DEFAULT_COLORS.copy()
+
+        # Plot-Einstellungen
+        self.plot_settings = {
+            'stack_mode': True,
+            'xlabel': 'q / nm⁻¹',
+            'ylabel': 'Intensität / a.u.',
+            'show_grid': True,
+            'grid_which': 'both',
+            'grid_alpha': 0.3,
+            'legend_fontsize': 10,
+            'axis_fontsize': 12,
+            'figure_dpi': 100,
+            'export_dpi': 300,
+        }
+
+        # Drag & Drop State
+        self.drag_data = None
+
+        # GUI erstellen
+        self.create_gui()
+        self.create_menu()
+
+    def create_menu(self):
+        """Erstellt die Menüleiste"""
+        menubar = tk.Menu(self.root)
+        self.root.config(menu=menubar)
+
+        # Datei-Menü
+        file_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Datei", menu=file_menu)
+        file_menu.add_command(label="Session speichern", command=self.save_session)
+        file_menu.add_command(label="Session laden", command=self.load_session)
+        file_menu.add_separator()
+        file_menu.add_command(label="Exportieren als PNG", command=self.export_png)
+        file_menu.add_command(label="Exportieren als SVG", command=self.export_svg)
+        file_menu.add_separator()
+        file_menu.add_command(label="Beenden", command=self.root.quit)
+
+        # Plot-Menü
+        plot_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Plot", menu=plot_menu)
+        plot_menu.add_command(label="Aktualisieren", command=self.update_plot)
+        plot_menu.add_command(label="Einstellungen", command=self.show_plot_settings)
+
+        # Hilfe-Menü
+        help_menu = tk.Menu(menubar, tearoff=0)
+        menubar.add_cascade(label="Hilfe", menu=help_menu)
+        help_menu.add_command(label="Über", command=self.show_about)
+
+    def create_gui(self):
+        """Erstellt die grafische Benutzeroberfläche"""
+
+        # Hauptcontainer mit Paned Window
+        main_paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
+        main_paned.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        # Linke Seite: Datenverwaltung
+        left_frame = ttk.Frame(main_paned, width=450)
+        main_paned.add(left_frame, weight=1)
+
+        # Rechte Seite: Plot
+        right_frame = ttk.Frame(main_paned)
+        main_paned.add(right_frame, weight=3)
+
+        # === Linke Seite: Kontrollen ===
+
+        # Buttons für Datenverwaltung
+        button_frame = ttk.Frame(left_frame)
+        button_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ttk.Button(button_frame, text="➕ Neue Gruppe",
+                   command=self.create_group).pack(side=tk.LEFT, padx=2)
+        ttk.Button(button_frame, text="📁 Daten laden",
+                   command=self.load_data_simple).pack(side=tk.LEFT, padx=2)
+        ttk.Button(button_frame, text="🗑 Löschen",
+                   command=self.delete_selected).pack(side=tk.LEFT, padx=2)
+
+        # Treeview für Gruppen und Datensätze
+        tree_frame = ttk.Frame(left_frame)
+        tree_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        # Scrollbars
+        tree_scroll_y = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL)
+        tree_scroll_y.pack(side=tk.RIGHT, fill=tk.Y)
+
+        self.tree = ttk.Treeview(tree_frame,
+                                  columns=("info",),
+                                  yscrollcommand=tree_scroll_y.set)
+        self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        tree_scroll_y.config(command=self.tree.yview)
+
+        self.tree.heading("#0", text="Name")
+        self.tree.heading("info", text="Info")
+        self.tree.column("info", width=100)
+
+        # Event-Bindings für Drag & Drop und Kontextmenü
+        self.tree.bind("<ButtonPress-1>", self.on_tree_press)
+        self.tree.bind("<B1-Motion>", self.on_tree_motion)
+        self.tree.bind("<ButtonRelease-1>", self.on_tree_release)
+        self.tree.bind("<Double-Button-1>", self.on_tree_double_click)
+        self.tree.bind("<Button-3>", self.show_context_menu)  # Rechtsklick
+
+        # Kontext-Menü erstellen
+        self.context_menu = tk.Menu(self.root, tearoff=0)
+        self.context_menu.add_command(label="Umbenennen", command=self.rename_item)
+        self.context_menu.add_command(label="Farbe ändern", command=self.change_color)
+        self.context_menu.add_command(label="Stil ändern", command=self.change_style)
+        self.context_menu.add_separator()
+        self.context_menu.add_command(label="Löschen", command=self.delete_selected)
+
+        # Schnell-Optionen
+        options_frame = ttk.LabelFrame(left_frame, text="Schnell-Optionen")
+        options_frame.pack(fill=tk.X, padx=5, pady=5)
+
+        ttk.Label(options_frame, text="Stack-Modus:").grid(row=0, column=0,
+                                                            sticky=tk.W, padx=5, pady=2)
+        self.stack_mode_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(options_frame, text="Aktiviert",
+                        variable=self.stack_mode_var,
+                        command=self.update_plot).grid(row=0, column=1,
+                                                        sticky=tk.W, padx=5, pady=2)
+
+        ttk.Label(options_frame, text="Grid:").grid(row=1, column=0,
+                                                     sticky=tk.W, padx=5, pady=2)
+        self.grid_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(options_frame, text="Anzeigen",
+                        variable=self.grid_var,
+                        command=self.update_plot).grid(row=1, column=1,
+                                                        sticky=tk.W, padx=5, pady=2)
+
+        options_frame.columnconfigure(1, weight=1)
+
+        # Plot-Button
+        plot_button_frame = ttk.Frame(left_frame)
+        plot_button_frame.pack(fill=tk.X, padx=5, pady=5)
+        ttk.Button(plot_button_frame, text="🔄 Plot aktualisieren",
+                   command=self.update_plot).pack(fill=tk.X)
+
+        # === Rechte Seite: Matplotlib Plot ===
+
+        self.fig = Figure(figsize=(12, 9), dpi=self.plot_settings['figure_dpi'])
+        self.ax = self.fig.add_subplot(111)
+
+        self.canvas = FigureCanvasTkAgg(self.fig, master=right_frame)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        # Matplotlib Toolbar
+        toolbar = NavigationToolbar2Tk(self.canvas, right_frame)
+        toolbar.update()
+
+        # Initial-Plot
+        self.update_plot()
+
+    # ========================================================================
+    # Drag & Drop Funktionalität
+    # ========================================================================
+
+    def on_tree_press(self, event):
+        """Start von Drag & Drop"""
+        item = self.tree.identify_row(event.y)
+        if item:
+            self.drag_data = {'item': item, 'start_y': event.y}
+
+    def on_tree_motion(self, event):
+        """Während Drag & Drop"""
+        if self.drag_data and abs(event.y - self.drag_data['start_y']) > 5:
+            # Cursor ändern um Drag zu signalisieren
+            self.tree.config(cursor="hand2")
+
+    def on_tree_release(self, event):
+        """Ende von Drag & Drop"""
+        if self.drag_data:
+            source_item = self.drag_data['item']
+            target_item = self.tree.identify_row(event.y)
+
+            if target_item and source_item != target_item:
+                # Prüfen ob Datensatz auf Gruppe gedroppt wird
+                source_parent = self.tree.parent(source_item)
+                target_parent = self.tree.parent(target_item)
+
+                # Datensatz wird auf Gruppe gedroppt
+                if source_parent and not target_parent:
+                    self.move_dataset_to_group(source_item, target_item)
+                # Datensatz wird auf Datensatz gedroppt (zur gleichen Gruppe)
+                elif source_parent and target_parent:
+                    self.move_dataset_to_group(source_item, target_parent)
+
+            self.tree.config(cursor="")
+            self.drag_data = None
+
+    def move_dataset_to_group(self, dataset_item, target_group_item):
+        """Verschiebt einen Datensatz in eine andere Gruppe"""
+        # Namen ermitteln
+        dataset_name = self.tree.item(dataset_item, 'text')
+        source_group_name = self.tree.item(self.tree.parent(dataset_item), 'text')
+        target_group_name = self.tree.item(target_group_item, 'text')
+
+        if source_group_name == target_group_name:
+            return  # Gleiche Gruppe
+
+        # Datensatz und Gruppen finden
+        source_group = next((g for g in self.groups if g.name == source_group_name), None)
+        target_group = next((g for g in self.groups if g.name == target_group_name), None)
+
+        if source_group and target_group:
+            dataset = next((d for d in source_group.datasets if d.name == dataset_name), None)
+            if dataset:
+                # Verschieben
+                source_group.remove_dataset(dataset)
+                target_group.add_dataset(dataset)
+
+                # Tree aktualisieren
+                self.tree.delete(dataset_item)
+                self.tree.insert(target_group_item, tk.END, text=dataset.display_label,
+                               values=("",), tags=("dataset",))
+
+                self.update_plot()
+
+    # ========================================================================
+    # Kontextmenü und Bearbeitungs-Funktionen
+    # ========================================================================
+
+    def show_context_menu(self, event):
+        """Zeigt Kontextmenü bei Rechtsklick"""
+        item = self.tree.identify_row(event.y)
+        if item:
+            self.tree.selection_set(item)
+            self.context_menu.post(event.x_root, event.y_root)
+
+    def on_tree_double_click(self, event):
+        """Doppelklick zum schnellen Bearbeiten"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        parent = self.tree.parent(item)
+
+        if not parent:  # Gruppe
+            self.edit_stack_factor(item)
+        else:  # Datensatz
+            self.rename_item()
+
+    def rename_item(self):
+        """Benennt Gruppe oder Datensatz um"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        item_text = self.tree.item(item, 'text')
+        parent = self.tree.parent(item)
+
+        new_name = simpledialog.askstring("Umbenennen", "Neuer Name:", initialvalue=item_text)
+        if not new_name:
+            return
+
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group:
+                group.name = new_name
+                self.tree.item(item, text=new_name)
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset:
+                    dataset.display_label = new_name
+                    self.tree.item(item, text=new_name)
+
+        self.update_plot()
+
+    def change_color(self):
+        """Ändert die Farbe einer Gruppe oder eines Datensatzes"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        item_text = self.tree.item(item, 'text')
+        parent = self.tree.parent(item)
+
+        # Aktuelle Farbe ermitteln
+        current_color = '#0069b4'
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group and group.color:
+                current_color = group.color
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset and dataset.color:
+                    current_color = dataset.color
+
+        # Farbauswahl-Dialog
+        color = colorchooser.askcolor(color=current_color, title="Farbe wählen")
+        if not color[1]:
+            return
+
+        new_color = color[1]
+
+        # Farbe setzen
+        if not parent:  # Gruppe
+            group = next((g for g in self.groups if g.name == item_text), None)
+            if group:
+                group.color = new_color
+        else:  # Datensatz
+            parent_name = self.tree.item(parent, 'text')
+            group = next((g for g in self.groups if g.name == parent_name), None)
+            if group:
+                dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                if dataset:
+                    dataset.color = new_color
+
+        self.update_plot()
+
+    def change_style(self):
+        """Ändert den Stil eines Datensatzes (Linientyp, Marker)"""
+        selected = self.tree.selection()
+        if not selected:
+            return
+
+        item = selected[0]
+        parent = self.tree.parent(item)
+
+        if not parent:
+            messagebox.showinfo("Info", "Stil kann nur für Datensätze geändert werden")
+            return
+
+        item_text = self.tree.item(item, 'text')
+        parent_name = self.tree.item(parent, 'text')
+        group = next((g for g in self.groups if g.name == parent_name), None)
+
+        if not group:
+            return
+
+        dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+        if not dataset:
+            return
+
+        # Dialog für Stil-Einstellungen
+        StyleDialog(self.root, dataset, self.update_plot)
+
+    def edit_stack_factor(self, item=None):
+        """Bearbeitet den Stack-Faktor einer Gruppe"""
+        if item is None:
+            selected = self.tree.selection()
+            if not selected:
+                return
+            item = selected[0]
+
+        parent = self.tree.parent(item)
+        if parent:  # Nur für Gruppen
+            return
+
+        item_text = self.tree.item(item, 'text')
+        group = next((g for g in self.groups if g.name == item_text), None)
+
+        if group:
+            new_factor = simpledialog.askfloat("Stack-Faktor bearbeiten",
+                                                f"Neuer Stack-Faktor für '{group.name}':",
+                                                initialvalue=group.stack_factor)
+            if new_factor is not None:
+                group.stack_factor = new_factor
+                self.tree.item(item, values=(f"×{new_factor}",))
+                self.update_plot()
+
+    # ========================================================================
+    # Daten laden und verwalten
+    # ========================================================================
+
+    def create_group(self):
+        """Erstellt eine neue Gruppe"""
+        name = simpledialog.askstring("Neue Gruppe", "Gruppenname:")
+        if not name:
+            return
+
+        stack_factor = simpledialog.askfloat("Stack-Faktor",
+                                              "Stack-Faktor (z.B. 1, 10, 100):",
+                                              initialvalue=1.0)
+        if stack_factor is None:
+            stack_factor = 1.0
+
+        group = DataGroup(name, stack_factor)
+        self.groups.append(group)
+
+        # In Treeview einfügen
+        group_id = self.tree.insert("", tk.END, text=name,
+                                    values=(f"×{stack_factor}",),
+                                    tags=("group",))
+        self.tree.item(group_id, open=True)
+
+    def load_data_simple(self):
+        """Einfaches Laden von Daten - Dateien wählen, dann Gruppe zuordnen"""
+        # Dateien auswählen
+        filepaths = filedialog.askopenfilenames(
+            title="Datensätze auswählen",
+            filetypes=[("Alle Dateien", "*.*"),
+                       ("Text-Dateien", "*.txt"),
+                       ("CSV-Dateien", "*.csv"),
+                       ("DAT-Dateien", "*.dat")]
+        )
+
+        if not filepaths:
+            return
+
+        # Falls keine Gruppen vorhanden, eine erstellen
+        if not self.groups:
+            self.create_group()
+            if not self.groups:  # Benutzer hat abgebrochen
+                return
+
+        # Gruppe auswählen
+        group_names = [g.name for g in self.groups]
+        if len(group_names) == 1:
+            group_name = group_names[0]
+        else:
+            group_name = simpledialog.askstring("Gruppe wählen",
+                                                f"Gruppenname (verfügbar: {', '.join(group_names)}):")
+
+        group = next((g for g in self.groups if g.name == group_name), None)
+        if not group:
+            messagebox.showerror("Fehler", f"Gruppe '{group_name}' nicht gefunden")
+            return
+
+        # Dateien laden
+        for filepath in filepaths:
+            try:
+                dataset = DataSet(filepath)
+                group.add_dataset(dataset)
+
+                # In Treeview einfügen
+                for item in self.tree.get_children():
+                    if self.tree.item(item, "text") == group.name:
+                        self.tree.insert(item, tk.END, text=dataset.display_label,
+                                        values=("",), tags=("dataset",))
+                        break
+
+            except Exception as e:
+                messagebox.showerror("Fehler", f"Fehler beim Laden von {filepath}:\n{e}")
+
+        self.update_plot()
+
+    def delete_selected(self):
+        """Löscht ausgewählte Gruppe oder Datensatz"""
+        selected = self.tree.selection()
+        if not selected:
+            messagebox.showwarning("Keine Auswahl", "Bitte wählen Sie ein Element aus")
+            return
+
+        for item in selected:
+            item_text = self.tree.item(item, "text")
+            parent = self.tree.parent(item)
+
+            if not parent:  # Gruppe
+                group = next((g for g in self.groups if g.name == item_text), None)
+                if group:
+                    self.groups.remove(group)
+            else:  # Datensatz
+                parent_text = self.tree.item(parent, "text")
+                group = next((g for g in self.groups if g.name == parent_text), None)
+                if group:
+                    dataset = next((d for d in group.datasets if d.display_label == item_text), None)
+                    if dataset:
+                        group.remove_dataset(dataset)
+
+            self.tree.delete(item)
+
+        self.update_plot()
+
+    # ========================================================================
+    # Plot-Funktionen
+    # ========================================================================
+
+    def update_plot(self):
+        """Aktualisiert den Plot mit allen Gruppen und Datensätzen"""
+        self.ax.clear()
+
+        if not self.groups:
+            self.ax.text(0.5, 0.5, "Keine Daten geladen\n\nDateien per Drag & Drop oder '📁 Daten laden'",
+                        ha='center', va='center', transform=self.ax.transAxes,
+                        fontsize=14, color='gray')
+            self.canvas.draw()
+            return
+
+        # Farbpalette vorbereiten
+        colors = self.color_palette.copy()
+
+        stack_mode = self.stack_mode_var.get()
+
+        # Plot jede Gruppe
+        for group_idx, group in enumerate(self.groups):
+            if not group.datasets:
+                continue
+
+            # Farbe für die Gruppe
+            group_color = group.color if group.color else colors[group_idx % len(colors)]
+
+            # Stack-Faktor
+            stack_factor = group.stack_factor if stack_mode else 1.0
+
+            # Plot jeden Datensatz in der Gruppe
+            for ds_idx, dataset in enumerate(group.datasets):
+                if dataset.x is None or dataset.y is None:
+                    continue
+
+                # Y-Werte mit Stack-Faktor
+                y_plot = dataset.y * stack_factor
+
+                # Farbe: Datensatz-Farbe oder Gruppenfarbe
+                plot_color = dataset.color if dataset.color else group_color
+
+                # Label
+                if dataset.show_in_legend:
+                    if stack_mode and ds_idx == 0:
+                        label = f"{group.name} (×{stack_factor}) - {dataset.display_label}"
+                    else:
+                        label = f"{group.name} - {dataset.display_label}"
+                else:
+                    label = None
+
+                # Plot-Stil
+                plot_style = dataset.get_plot_style()
+
+                # Hauptplot
+                self.ax.plot(dataset.x, y_plot, plot_style,
+                           color=plot_color,
+                           linewidth=dataset.line_width,
+                           markersize=dataset.marker_size,
+                           label=label,
+                           alpha=0.8)
+
+                # Fehlerbereich
+                if dataset.y_err is not None:
+                    y_err_plot = dataset.y_err * stack_factor
+                    self.ax.fill_between(dataset.x,
+                                        y_plot - y_err_plot,
+                                        y_plot + y_err_plot,
+                                        color=plot_color,
+                                        alpha=0.2)
+
+        # Achsen-Einstellungen
+        self.ax.set_xscale('log')
+        self.ax.set_yscale('log')
+        self.ax.set_xlabel(self.plot_settings['xlabel'],
+                          fontsize=self.plot_settings['axis_fontsize'])
+        self.ax.set_ylabel(self.plot_settings['ylabel'],
+                          fontsize=self.plot_settings['axis_fontsize'])
+
+        if self.grid_var.get():
+            self.ax.grid(True,
+                        alpha=self.plot_settings['grid_alpha'],
+                        which=self.plot_settings['grid_which'])
+
+        self.ax.legend(fontsize=self.plot_settings['legend_fontsize'],
+                      framealpha=0.9)
+
+        self.fig.tight_layout()
+        self.canvas.draw()
+
+    def show_plot_settings(self):
+        """Zeigt Dialog für erweiterte Plot-Einstellungen"""
+        PlotSettingsDialog(self.root, self.plot_settings, self.update_plot)
+
+    # ========================================================================
+    # Session speichern/laden
+    # ========================================================================
+
+    def save_session(self):
+        """Speichert die aktuelle Session"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            title="Session speichern"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            session_data = {
+                'groups': [g.to_dict() for g in self.groups],
+                'plot_settings': self.plot_settings,
+                'color_palette': self.color_palette
+            }
+
+            with open(filepath, 'w', encoding='utf-8') as f:
+                json.dump(session_data, f, indent=2)
+
+            messagebox.showinfo("Erfolg", f"Session gespeichert in:\n{filepath}")
+
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Speichern:\n{e}")
+
+    def load_session(self):
+        """Lädt eine gespeicherte Session"""
+        filepath = filedialog.askopenfilename(
+            filetypes=[("JSON Dateien", "*.json"), ("Alle Dateien", "*.*")],
+            title="Session laden"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                session_data = json.load(f)
+
+            # Alte Daten löschen
+            self.groups.clear()
+            for item in self.tree.get_children():
+                self.tree.delete(item)
+
+            # Gruppen laden
+            for group_data in session_data.get('groups', []):
+                group = DataGroup.from_dict(group_data)
+                self.groups.append(group)
+
+                # In Tree einfügen
+                group_id = self.tree.insert("", tk.END, text=group.name,
+                                           values=(f"×{group.stack_factor}",),
+                                           tags=("group",))
+                self.tree.item(group_id, open=True)
+
+                for dataset in group.datasets:
+                    self.tree.insert(group_id, tk.END, text=dataset.display_label,
+                                   values=("",), tags=("dataset",))
+
+            # Einstellungen laden
+            if 'plot_settings' in session_data:
+                self.plot_settings.update(session_data['plot_settings'])
+
+            if 'color_palette' in session_data:
+                self.color_palette = session_data['color_palette']
+
+            self.update_plot()
+            messagebox.showinfo("Erfolg", "Session geladen")
+
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Laden:\n{e}")
+
+    # ========================================================================
+    # Export-Funktionen
+    # ========================================================================
+
+    def export_png(self):
+        """Exportiert den Plot als PNG"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".png",
+            filetypes=[("PNG Dateien", "*.png"), ("Alle Dateien", "*.*")],
+            title="Als PNG exportieren"
+        )
+
+        if not filepath:
+            return
+
+        # DPI abfragen
+        dpi = simpledialog.askinteger("Export DPI",
+                                      "DPI für Export (z.B. 300 für Publikation):",
+                                      initialvalue=self.plot_settings['export_dpi'],
+                                      minvalue=72,
+                                      maxvalue=1200)
+        if not dpi:
+            dpi = self.plot_settings['export_dpi']
+
+        try:
+            self.fig.savefig(filepath, dpi=dpi, bbox_inches='tight', facecolor='white')
+            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}\nDPI: {dpi}")
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
+
+    def export_svg(self):
+        """Exportiert den Plot als SVG"""
+        filepath = filedialog.asksaveasfilename(
+            defaultextension=".svg",
+            filetypes=[("SVG Dateien", "*.svg"), ("Alle Dateien", "*.*")],
+            title="Als SVG exportieren"
+        )
+
+        if not filepath:
+            return
+
+        try:
+            self.fig.savefig(filepath, format='svg', bbox_inches='tight')
+            messagebox.showinfo("Erfolg", f"Plot exportiert als:\n{filepath}")
+        except Exception as e:
+            messagebox.showerror("Fehler", f"Fehler beim Exportieren:\n{e}")
+
+    def show_about(self):
+        """Zeigt Über-Dialog"""
+        about_text = """TUBAF Scattering Plot Tool
+Version 2.0
+
+Entwickelt für die TU Bergakademie Freiberg
+
+Features:
+• Drag & Drop Gruppenzuordnung
+• Individuelle Farb- und Stil-Anpassung
+• PNG/SVG Export
+• Session speichern/laden
+• 4K Display-Unterstützung
+
+© 2024 TU Bergakademie Freiberg"""
+
+        messagebox.showinfo("Über", about_text)
+
+
+# ============================================================================
+# Dialog-Klassen
+# ============================================================================
+
+class StyleDialog:
+    """Dialog zum Ändern des Datensatz-Stils"""
+    def __init__(self, parent, dataset, update_callback):
+        self.dataset = dataset
+        self.update_callback = update_callback
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title(f"Stil ändern: {dataset.display_label}")
+        self.dialog.geometry("400x350")
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+
+        # Linientyp
+        ttk.Label(self.dialog, text="Linientyp:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        self.line_var = tk.StringVar(value=dataset.line_style or 'auto')
+        line_combo = ttk.Combobox(self.dialog, textvariable=self.line_var,
+                                   values=['auto', '-', '--', '-.', ':', ''], width=15)
+        line_combo.grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Markertyp
+        ttk.Label(self.dialog, text="Marker:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
+        self.marker_var = tk.StringVar(value=dataset.marker_style or 'auto')
+        marker_combo = ttk.Combobox(self.dialog, textvariable=self.marker_var,
+                                     values=['auto', 'o', 's', '^', 'v', 'D', '*', '+', 'x', ''], width=15)
+        marker_combo.grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Linienbreite
+        ttk.Label(self.dialog, text="Linienbreite:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
+        self.linewidth_var = tk.DoubleVar(value=dataset.line_width)
+        ttk.Spinbox(self.dialog, from_=0.5, to=10, increment=0.5,
+                    textvariable=self.linewidth_var, width=15).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Markergröße
+        ttk.Label(self.dialog, text="Markergröße:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
+        self.markersize_var = tk.DoubleVar(value=dataset.marker_size)
+        ttk.Spinbox(self.dialog, from_=1, to=20, increment=1,
+                    textvariable=self.markersize_var, width=15).grid(row=3, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # In Legende anzeigen
+        ttk.Label(self.dialog, text="In Legende:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_var = tk.BooleanVar(value=dataset.show_in_legend)
+        ttk.Checkbutton(self.dialog, text="Anzeigen",
+                        variable=self.legend_var).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Buttons
+        button_frame = ttk.Frame(self.dialog)
+        button_frame.grid(row=5, column=0, columnspan=2, pady=20)
+
+        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+
+    def apply(self):
+        """Wendet die Änderungen an"""
+        line_val = self.line_var.get()
+        self.dataset.line_style = None if line_val == 'auto' else line_val
+
+        marker_val = self.marker_var.get()
+        self.dataset.marker_style = None if marker_val == 'auto' else marker_val
+
+        self.dataset.line_width = self.linewidth_var.get()
+        self.dataset.marker_size = self.markersize_var.get()
+        self.dataset.show_in_legend = self.legend_var.get()
+
+        self.update_callback()
+        self.dialog.destroy()
+
+
+class PlotSettingsDialog:
+    """Dialog für erweiterte Plot-Einstellungen"""
+    def __init__(self, parent, settings, update_callback):
+        self.settings = settings
+        self.update_callback = update_callback
+
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Plot-Einstellungen")
+        self.dialog.geometry("500x450")
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+
+        # X-Label
+        ttk.Label(self.dialog, text="X-Achsen Label:").grid(row=0, column=0, sticky=tk.W, padx=10, pady=5)
+        self.xlabel_var = tk.StringVar(value=settings['xlabel'])
+        ttk.Entry(self.dialog, textvariable=self.xlabel_var, width=30).grid(row=0, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Y-Label
+        ttk.Label(self.dialog, text="Y-Achsen Label:").grid(row=1, column=0, sticky=tk.W, padx=10, pady=5)
+        self.ylabel_var = tk.StringVar(value=settings['ylabel'])
+        ttk.Entry(self.dialog, textvariable=self.ylabel_var, width=30).grid(row=1, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Grid
+        ttk.Label(self.dialog, text="Grid Modus:").grid(row=2, column=0, sticky=tk.W, padx=10, pady=5)
+        self.grid_which_var = tk.StringVar(value=settings['grid_which'])
+        ttk.Combobox(self.dialog, textvariable=self.grid_which_var,
+                     values=['both', 'major', 'minor'], width=27).grid(row=2, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Grid Alpha
+        ttk.Label(self.dialog, text="Grid Transparenz:").grid(row=3, column=0, sticky=tk.W, padx=10, pady=5)
+        self.grid_alpha_var = tk.DoubleVar(value=settings['grid_alpha'])
+        ttk.Scale(self.dialog, from_=0, to=1, variable=self.grid_alpha_var,
+                  orient=tk.HORIZONTAL).grid(row=3, column=1, sticky=tk.EW, padx=10, pady=5)
+
+        # Legenden-Schriftgröße
+        ttk.Label(self.dialog, text="Legenden-Schriftgröße:").grid(row=4, column=0, sticky=tk.W, padx=10, pady=5)
+        self.legend_fontsize_var = tk.IntVar(value=settings['legend_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.legend_fontsize_var,
+                    width=27).grid(row=4, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Achsen-Schriftgröße
+        ttk.Label(self.dialog, text="Achsen-Schriftgröße:").grid(row=5, column=0, sticky=tk.W, padx=10, pady=5)
+        self.axis_fontsize_var = tk.IntVar(value=settings['axis_fontsize'])
+        ttk.Spinbox(self.dialog, from_=6, to=20, textvariable=self.axis_fontsize_var,
+                    width=27).grid(row=5, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Export DPI
+        ttk.Label(self.dialog, text="Standard Export DPI:").grid(row=6, column=0, sticky=tk.W, padx=10, pady=5)
+        self.export_dpi_var = tk.IntVar(value=settings['export_dpi'])
+        ttk.Spinbox(self.dialog, from_=72, to=1200, increment=50,
+                    textvariable=self.export_dpi_var, width=27).grid(row=6, column=1, sticky=tk.W, padx=10, pady=5)
+
+        # Buttons
+        button_frame = ttk.Frame(self.dialog)
+        button_frame.grid(row=7, column=0, columnspan=2, pady=20)
+
+        ttk.Button(button_frame, text="Übernehmen", command=self.apply).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="Abbrechen", command=self.dialog.destroy).pack(side=tk.LEFT, padx=5)
+
+    def apply(self):
+        """Wendet die Änderungen an"""
+        self.settings['xlabel'] = self.xlabel_var.get()
+        self.settings['ylabel'] = self.ylabel_var.get()
+        self.settings['grid_which'] = self.grid_which_var.get()
+        self.settings['grid_alpha'] = self.grid_alpha_var.get()
+        self.settings['legend_fontsize'] = self.legend_fontsize_var.get()
+        self.settings['axis_fontsize'] = self.axis_fontsize_var.get()
+        self.settings['export_dpi'] = self.export_dpi_var.get()
+
+        self.update_callback()
+        self.dialog.destroy()
+
+
+# ============================================================================
+# Hauptfunktion
+# ============================================================================
+
+def main():
+    """Hauptfunktion"""
+    # DPI Awareness aktivieren
+    enable_dpi_awareness()
+
+    root = tk.Tk()
+
+    # Verbesserte DPI-Skalierung für Linux/X11
+    if platform.system() == 'Linux':
+        try:
+            dpi = root.winfo_fpixels('1i')
+            if dpi > 96:  # 4K oder High-DPI Display
+                scale_factor = dpi / 96
+                root.tk.call('tk', 'scaling', scale_factor)
+        except:
+            pass
+
+    app = ScatterPlotApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/user_config.py
+++ b/user_config.py
@@ -1,0 +1,341 @@
+"""
+User Configuration Management für TUBAF Scattering Plot Tool
+
+Verwaltet persistente Einstellungen:
+- Farbschemata (eigene + matplotlib)
+- Stil-Vorlagen
+- Auto-Erkennungs-Regeln
+- Letzte Pfade, Einstellungen, etc.
+"""
+
+import json
+from pathlib import Path
+import os
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+
+
+# User Config Verzeichnis
+CONFIG_DIR = Path.home() / ".tubaf_scatter_plots"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+SCHEMES_FILE = CONFIG_DIR / "color_schemes.json"
+STYLES_FILE = CONFIG_DIR / "style_presets.json"
+
+
+def ensure_config_dir():
+    """Stellt sicher, dass das Config-Verzeichnis existiert"""
+    CONFIG_DIR.mkdir(exist_ok=True)
+
+
+def get_matplotlib_colormaps():
+    """
+    Gibt eine Liste aller verfügbaren matplotlib Colormaps zurück
+
+    Returns:
+        dict: {name: [list of hex colors]}
+    """
+    colormaps = {}
+
+    # Qualitative Colormaps (gut für diskrete Datensätze)
+    qualitative = [
+        'tab10', 'tab20', 'tab20b', 'tab20c',
+        'Set1', 'Set2', 'Set3', 'Paired', 'Accent', 'Pastel1', 'Pastel2', 'Dark2'
+    ]
+
+    # Sequential Colormaps
+    sequential = [
+        'viridis', 'plasma', 'inferno', 'magma', 'cividis',
+        'Blues', 'Greens', 'Reds', 'Oranges', 'Purples',
+        'YlOrRd', 'YlOrBr', 'YlGnBu', 'RdPu', 'BuPu', 'GnBu'
+    ]
+
+    # Diverging Colormaps
+    diverging = [
+        'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic'
+    ]
+
+    all_cmaps = qualitative + sequential + diverging
+
+    for cmap_name in all_cmaps:
+        try:
+            cmap = cm.get_cmap(cmap_name)
+            # 10 Farben aus der Colormap sampeln
+            n_colors = 10
+            colors = []
+            for i in range(n_colors):
+                rgba = cmap(i / n_colors)
+                # RGBA zu Hex
+                hex_color = '#{:02x}{:02x}{:02x}'.format(
+                    int(rgba[0] * 255),
+                    int(rgba[1] * 255),
+                    int(rgba[2] * 255)
+                )
+                colors.append(hex_color)
+            colormaps[cmap_name] = colors
+        except:
+            pass
+
+    return colormaps
+
+
+# Standard Stil-Vorlagen
+DEFAULT_STYLE_PRESETS = {
+    'Messung': {
+        'line_style': '',
+        'marker_style': 'o',
+        'line_width': 1.5,
+        'marker_size': 4,
+        'description': 'Für Messdaten mit Fehlerbalken'
+    },
+    'Fit': {
+        'line_style': '-',
+        'marker_style': '',
+        'line_width': 2,
+        'marker_size': 0,
+        'description': 'Für Fit-Kurven (durchgezogene Linie)'
+    },
+    'Simulation': {
+        'line_style': '--',
+        'marker_style': '',
+        'line_width': 1.5,
+        'marker_size': 0,
+        'description': 'Für Simulationen (gestrichelte Linie)'
+    },
+    'Theorie': {
+        'line_style': '-.',
+        'marker_style': '',
+        'line_width': 1.5,
+        'marker_size': 0,
+        'description': 'Für theoretische Kurven (Strich-Punkt)'
+    }
+}
+
+
+# Standard Auto-Erkennungs-Regeln
+DEFAULT_AUTO_DETECTION_RULES = {
+    'fit': 'Fit',
+    'fitted': 'Fit',
+    'anpassung': 'Fit',
+    'messung': 'Messung',
+    'measurement': 'Messung',
+    'measure': 'Messung',
+    'data': 'Messung',
+    'daten': 'Messung',
+    'sim': 'Simulation',
+    'simulation': 'Simulation',
+    'theo': 'Theorie',
+    'theory': 'Theorie',
+    'theorie': 'Theorie'
+}
+
+
+class UserConfig:
+    """Verwaltet alle User-Einstellungen"""
+
+    def __init__(self):
+        ensure_config_dir()
+        self.config = self.load_config()
+        self.color_schemes = self.load_color_schemes()
+        self.style_presets = self.load_style_presets()
+        self.auto_detection_rules = self.config.get('auto_detection_rules', DEFAULT_AUTO_DETECTION_RULES.copy())
+        self.auto_detection_enabled = self.config.get('auto_detection_enabled', True)
+
+    def load_config(self):
+        """Lädt die Hauptkonfiguration"""
+        if CONFIG_FILE.exists():
+            try:
+                with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except:
+                pass
+
+        # Standard-Config
+        return {
+            'last_directory': str(Path.home()),
+            'last_export_directory': str(Path.home()),
+            'export_dpi': 300,
+            'window_geometry': '1600x1000',
+            'auto_detection_enabled': True,
+            'auto_detection_rules': DEFAULT_AUTO_DETECTION_RULES.copy()
+        }
+
+    def save_config(self):
+        """Speichert die Hauptkonfiguration"""
+        self.config['auto_detection_rules'] = self.auto_detection_rules
+        self.config['auto_detection_enabled'] = self.auto_detection_enabled
+
+        try:
+            with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+                json.dump(self.config, f, indent=2)
+        except Exception as e:
+            print(f"Fehler beim Speichern der Config: {e}")
+
+    def load_color_schemes(self):
+        """Lädt gespeicherte Farbschemata"""
+        schemes = {}
+
+        # TUBAF Standard
+        try:
+            from tu_freiberg_colors import PRIMARY, SECONDARY, TERTIARY
+            schemes['TUBAF'] = [
+                PRIMARY['uniblau']['hex'],
+                SECONDARY['geo']['hex'],
+                SECONDARY['material']['hex'],
+                SECONDARY['energie']['hex'],
+                SECONDARY['umwelt']['hex'],
+                TERTIARY['orange_2']['hex'],
+                TERTIARY['gruen_3']['hex'],
+                TERTIARY['tuerkis_2']['hex'],
+                TERTIARY['rot_6']['hex'],
+                TERTIARY['blau_2']['hex'],
+            ]
+        except:
+            schemes['TUBAF'] = ['#0069b4', '#8b7530', '#007b99', '#b71e3f', '#15882e',
+                                '#e18409', '#95c11f', '#1e959a', '#cd1222', '#a1d9ef']
+
+        # Matplotlib Colormaps
+        schemes.update(get_matplotlib_colormaps())
+
+        # User-definierte Schemata laden
+        if SCHEMES_FILE.exists():
+            try:
+                with open(SCHEMES_FILE, 'r', encoding='utf-8') as f:
+                    user_schemes = json.load(f)
+                    schemes.update(user_schemes)
+            except:
+                pass
+
+        return schemes
+
+    def save_color_scheme(self, name, colors):
+        """Speichert ein neues Farbschema"""
+        # Nur user-definierte Schemata speichern (nicht TUBAF oder matplotlib)
+        user_schemes = {}
+        if SCHEMES_FILE.exists():
+            try:
+                with open(SCHEMES_FILE, 'r', encoding='utf-8') as f:
+                    user_schemes = json.load(f)
+            except:
+                pass
+
+        user_schemes[name] = colors
+
+        try:
+            with open(SCHEMES_FILE, 'w', encoding='utf-8') as f:
+                json.dump(user_schemes, f, indent=2)
+
+            self.color_schemes[name] = colors
+            return True
+        except Exception as e:
+            print(f"Fehler beim Speichern des Farbschemas: {e}")
+            return False
+
+    def delete_color_scheme(self, name):
+        """Löscht ein user-definiertes Farbschema"""
+        if name in ['TUBAF'] or name in get_matplotlib_colormaps():
+            return False  # Standard-Schemata können nicht gelöscht werden
+
+        if SCHEMES_FILE.exists():
+            try:
+                with open(SCHEMES_FILE, 'r', encoding='utf-8') as f:
+                    user_schemes = json.load(f)
+
+                if name in user_schemes:
+                    del user_schemes[name]
+
+                    with open(SCHEMES_FILE, 'w', encoding='utf-8') as f:
+                        json.dump(user_schemes, f, indent=2)
+
+                    if name in self.color_schemes:
+                        del self.color_schemes[name]
+
+                    return True
+            except:
+                pass
+
+        return False
+
+    def load_style_presets(self):
+        """Lädt Stil-Vorlagen"""
+        if STYLES_FILE.exists():
+            try:
+                with open(STYLES_FILE, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+            except:
+                pass
+
+        return DEFAULT_STYLE_PRESETS.copy()
+
+    def save_style_presets(self):
+        """Speichert Stil-Vorlagen"""
+        try:
+            with open(STYLES_FILE, 'w', encoding='utf-8') as f:
+                json.dump(self.style_presets, f, indent=2)
+            return True
+        except Exception as e:
+            print(f"Fehler beim Speichern der Stil-Vorlagen: {e}")
+            return False
+
+    def add_style_preset(self, name, style_dict):
+        """Fügt eine neue Stil-Vorlage hinzu"""
+        self.style_presets[name] = style_dict
+        return self.save_style_presets()
+
+    def delete_style_preset(self, name):
+        """Löscht eine Stil-Vorlage"""
+        if name in self.style_presets:
+            del self.style_presets[name]
+            return self.save_style_presets()
+        return False
+
+    def get_style_by_filename(self, filename):
+        """
+        Erkennt den Stil anhand des Dateinamens
+
+        Args:
+            filename: Dateiname oder Pfad
+
+        Returns:
+            dict or None: Stil-Dictionary oder None
+        """
+        if not self.auto_detection_enabled:
+            return None
+
+        filename_lower = Path(filename).stem.lower()
+
+        # Durchsuche Erkennungs-Regeln (erstes Match gewinnt)
+        for keyword, style_name in self.auto_detection_rules.items():
+            if keyword.lower() in filename_lower:
+                if style_name in self.style_presets:
+                    return self.style_presets[style_name].copy()
+
+        return None
+
+    def set_last_directory(self, directory):
+        """Speichert das zuletzt verwendete Verzeichnis"""
+        self.config['last_directory'] = str(directory)
+        self.save_config()
+
+    def get_last_directory(self):
+        """Gibt das zuletzt verwendete Verzeichnis zurück"""
+        return self.config.get('last_directory', str(Path.home()))
+
+    def set_export_dpi(self, dpi):
+        """Speichert die Standard-Export-DPI"""
+        self.config['export_dpi'] = dpi
+        self.save_config()
+
+    def get_export_dpi(self):
+        """Gibt die Standard-Export-DPI zurück"""
+        return self.config.get('export_dpi', 300)
+
+
+# Globale Config-Instanz
+_user_config = None
+
+def get_user_config():
+    """Gibt die globale UserConfig-Instanz zurück"""
+    global _user_config
+    if _user_config is None:
+        _user_config = UserConfig()
+    return _user_config


### PR DESCRIPTION
MAJOR UPDATE with extensive new features:

## New Features:

### Plot Types
- Log-Log, Porod (I·q⁴), Kratky (I·q²), Guinier (ln(I) vs q²)
- PDDF mode with subplot for pair distance distribution

### Data Management
- "Unassigned" section: Load files first, assign to groups via drag & drop
- Improved drag & drop: between groups, to/from unassigned
- Collapsible "Unassigned" section (double-click to toggle)

### Style System
- Style presets: Measurement, Fit, Simulation, Theory
- Auto-detection: Automatic style assignment based on filename keywords
- Design Manager dialog with 3 tabs:
  - Style Presets: Create and manage custom styles
  - Color Schemes: TUBAF + all matplotlib colormaps (30+) + custom
  - Auto-Detection Rules: Keyword → Style mapping

### Improved Legend
- Group headers with scale factors: "━━ Group A (×10) ━━"
- Individual legend entries for each dataset
- Prevents loss of scale factor info when hiding datasets

### Enhanced Settings
- Axis ranges: Manual min/max or automatic
- Legend position: best, upper/lower right/left, center
- All matplotlib colormaps accessible via dropdown

### User Configuration
- Persistent settings in ~/.tubaf_scatter_plots/
- Color schemes, style presets, auto-detection rules saved
- Last used directories and export DPI remembered

## Technical Improvements:
- user_config.py: Complete configuration management system
- get_matplotlib_colormaps(): Loads all qualitative, sequential, diverging maps
- transform_data(): Plot-type specific data transformations
- GridSpec for PDDF subplot layout
- Enhanced serialization for full session save/load

## Files:
- scatter_plot.py: Complete rewrite (1453 lines, was 1087)
- user_config.py: New configuration system
- scatter_plot_v2.py: Backup of previous version
- README.md: Updated documentation

## Workflow Improvements:
1. Load data → Auto-style applied
2. Drag to groups → Organize
3. Choose plot type → Auto-labels
4. Choose color scheme → 30+ options
5. Design Manager → Customize everything
6. Export → Settings remembered

This version addresses all user requests:
✓ Scale factor in legend (group headers)
✓ Unassigned data pool with drag & drop
✓ Plot types (Log-Log, Porod, Kratky, Guinier, PDDF) ✓ Axis range settings
✓ Style presets with auto-detection
✓ Color scheme manager (user config)
✓ All matplotlib colormaps
✓ First-match auto-detection logic