### PR TITLE
Fix reference line orientation bug

### DIFF
--- a/dialogs/reference_lines_dialog.py
+++ b/dialogs/reference_lines_dialog.py
@@ -107,7 +107,7 @@ class ReferenceLinesDialog(QDialog):
     def get_reference_line(self):
         """Gibt Referenzlinie-Dict zurück"""
         return {
-            'type': 'vertical' if self.type_combo.currentText() == 'Vertikal' else 'horizontal',
+            'type': 'vertical' if self.type_combo.currentIndex() == 0 else 'horizontal',
             'value': self.value_spin.value(),
             'label': self.label_edit.text(),
             'linestyle': self.linestyle_combo.currentText(),

--- a/scatter_plot.py
+++ b/scatter_plot.py
@@ -2490,7 +2490,7 @@ class ScatterPlotApp(QMainWindow):
             # Referenzlinien-Dialog mit vorausgefüllten Werten
             from dialogs.reference_lines_dialog import ReferenceLinesDialog
             dialog = ReferenceLinesDialog(self)
-            dialog.type_combo.setCurrentText('Vertikal' if obj['type'] == 'vertical' else 'Horizontal')
+            dialog.type_combo.setCurrentIndex(0 if obj['type'] == 'vertical' else 1)
             dialog.value_spin.setValue(obj['value'])
             dialog.label_edit.setText(obj.get('label', ''))
             dialog.linestyle_combo.setCurrentText(obj['linestyle'])


### PR DESCRIPTION
Fixed bug where vertical reference lines were always created as horizontal lines, regardless of the selected orientation in the dialog.

Root cause:
- The code was comparing the ComboBox text with the hardcoded German string 'Vertikal', which failed when the application was in English or when the comparison didn't match exactly
- This caused all reference lines to default to 'horizontal'

Solution:
- Use ComboBox currentIndex() instead of currentText() for language-independent comparison (index 0 = vertical, index 1 = horizontal)
- Updated both the dialog's get_reference_line() method and the edit dialog initialization in scatter_plot.py

Changes:
- dialogs/reference_lines_dialog.py:110 - Use currentIndex() == 0
- scatter_plot.py:2493 - Use setCurrentIndex(0 if ...) for initialization