### PR TITLE
Add font family selection and improve design persistence

### DIFF
--- a/dialogs/axes_dialog.py
+++ b/dialogs/axes_dialog.py
@@ -7,7 +7,7 @@ This dialog allows users to configure axis labels and titles.
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QGridLayout, QGroupBox,
     QLabel, QLineEdit, QDialogButtonBox, QCheckBox, QPushButton, QMessageBox, QHBoxLayout,
-    QSpinBox
+    QSpinBox, QFontComboBox
 )
 from utils.mathtext_formatter import get_syntax_help_text, preprocess_mathtext
 from i18n import tr
@@ -43,7 +43,6 @@ class AxesSettingsDialog(QDialog):
         titles_layout.addWidget(QLabel(tr("axes.axis_titles.x_title")), 0, 0)
         self.xlabel_edit = QLineEdit()
         self.xlabel_edit.setPlaceholderText(tr("axes.axis_titles.auto_based_on", plot_type=plot_type))
-        self.xlabel_edit.textChanged.connect(self.update_preview)
         if current_xlabel:
             self.xlabel_edit.setText(current_xlabel)
         titles_layout.addWidget(self.xlabel_edit, 0, 1)
@@ -52,7 +51,6 @@ class AxesSettingsDialog(QDialog):
         titles_layout.addWidget(QLabel(tr("axes.axis_titles.y_title")), 1, 0)
         self.ylabel_edit = QLineEdit()
         self.ylabel_edit.setPlaceholderText(tr("axes.axis_titles.auto_based_on", plot_type=plot_type))
-        self.ylabel_edit.textChanged.connect(self.update_preview)
         if current_ylabel:
             self.ylabel_edit.setText(current_ylabel)
         titles_layout.addWidget(self.ylabel_edit, 1, 1)
@@ -74,6 +72,10 @@ class AxesSettingsDialog(QDialog):
             "min-height: 40px;"
         )
         titles_layout.addWidget(self.preview_label, 3, 1)
+
+        # Connect signals AFTER all UI elements are created
+        self.xlabel_edit.textChanged.connect(self.update_preview)
+        self.ylabel_edit.textChanged.connect(self.update_preview)
 
         titles_group.setLayout(titles_layout)
         layout.addWidget(titles_group)
@@ -138,20 +140,31 @@ class AxesSettingsDialog(QDialog):
         labels_font_group = QGroupBox(tr("axes.font_labels.title"))
         labels_font_layout = QGridLayout()
 
-        labels_font_layout.addWidget(QLabel(tr("axes.font_labels.size")), 0, 0)
+        # Font Family
+        labels_font_layout.addWidget(QLabel(tr("axes.font_labels.family")), 0, 0)
+        self.labels_font_combo = QFontComboBox()
+        current_labels_font = self.font_settings.get('labels_font_family', 'Arial')
+        index = self.labels_font_combo.findText(current_labels_font)
+        if index >= 0:
+            self.labels_font_combo.setCurrentIndex(index)
+        labels_font_layout.addWidget(self.labels_font_combo, 0, 1)
+
+        # Font Size
+        labels_font_layout.addWidget(QLabel(tr("axes.font_labels.size")), 1, 0)
         self.labels_size_spin = QSpinBox()
         self.labels_size_spin.setRange(6, 32)
         self.labels_size_spin.setValue(self.font_settings.get('labels_size', 12))
         self.labels_size_spin.setSuffix(" pt")
-        labels_font_layout.addWidget(self.labels_size_spin, 0, 1)
+        labels_font_layout.addWidget(self.labels_size_spin, 1, 1)
 
+        # Bold & Italic
         self.labels_bold = QCheckBox(tr("axes.font_labels.bold"))
         self.labels_bold.setChecked(self.font_settings.get('labels_bold', False))
-        labels_font_layout.addWidget(self.labels_bold, 1, 0)
+        labels_font_layout.addWidget(self.labels_bold, 2, 0)
 
         self.labels_italic = QCheckBox(tr("axes.font_labels.italic"))
         self.labels_italic.setChecked(self.font_settings.get('labels_italic', False))
-        labels_font_layout.addWidget(self.labels_italic, 1, 1)
+        labels_font_layout.addWidget(self.labels_italic, 2, 1)
 
         labels_font_group.setLayout(labels_font_layout)
         layout.addWidget(labels_font_group)
@@ -160,20 +173,31 @@ class AxesSettingsDialog(QDialog):
         ticks_font_group = QGroupBox(tr("axes.font_ticks.title"))
         ticks_font_layout = QGridLayout()
 
-        ticks_font_layout.addWidget(QLabel(tr("axes.font_labels.size")), 0, 0)
+        # Font Family
+        ticks_font_layout.addWidget(QLabel(tr("axes.font_labels.family")), 0, 0)
+        self.ticks_font_combo = QFontComboBox()
+        current_ticks_font = self.font_settings.get('ticks_font_family', 'Arial')
+        index = self.ticks_font_combo.findText(current_ticks_font)
+        if index >= 0:
+            self.ticks_font_combo.setCurrentIndex(index)
+        ticks_font_layout.addWidget(self.ticks_font_combo, 0, 1)
+
+        # Font Size
+        ticks_font_layout.addWidget(QLabel(tr("axes.font_labels.size")), 1, 0)
         self.ticks_size_spin = QSpinBox()
         self.ticks_size_spin.setRange(6, 24)
         self.ticks_size_spin.setValue(self.font_settings.get('ticks_size', 10))
         self.ticks_size_spin.setSuffix(" pt")
-        ticks_font_layout.addWidget(self.ticks_size_spin, 0, 1)
+        ticks_font_layout.addWidget(self.ticks_size_spin, 1, 1)
 
+        # Bold & Italic
         self.ticks_bold = QCheckBox(tr("axes.font_labels.bold"))
         self.ticks_bold.setChecked(self.font_settings.get('ticks_bold', False))
-        ticks_font_layout.addWidget(self.ticks_bold, 1, 0)
+        ticks_font_layout.addWidget(self.ticks_bold, 2, 0)
 
         self.ticks_italic = QCheckBox(tr("axes.font_labels.italic"))
         self.ticks_italic.setChecked(self.font_settings.get('ticks_italic', False))
-        ticks_font_layout.addWidget(self.ticks_italic, 1, 1)
+        ticks_font_layout.addWidget(self.ticks_italic, 2, 1)
 
         ticks_font_group.setLayout(ticks_font_layout)
         layout.addWidget(ticks_font_group)
@@ -249,9 +273,11 @@ class AxesSettingsDialog(QDialog):
     def get_font_settings(self):
         """Gibt die Schriftart-Einstellungen zurück"""
         return {
+            'labels_font_family': self.labels_font_combo.currentText(),
             'labels_size': self.labels_size_spin.value(),
             'labels_bold': self.labels_bold.isChecked(),
             'labels_italic': self.labels_italic.isChecked(),
+            'ticks_font_family': self.ticks_font_combo.currentText(),
             'ticks_size': self.ticks_size_spin.value(),
             'ticks_bold': self.ticks_bold.isChecked(),
             'ticks_italic': self.ticks_italic.isChecked()

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -255,6 +255,7 @@
 
     "font_labels": {
       "title": "Schriftart Achsenbeschriftungen",
+      "family": "Schriftart:",
       "size": "Schriftgröße:",
       "bold": "Fett",
       "italic": "Kursiv"
@@ -673,6 +674,7 @@
       "standard_overwritten": "Standard-Design '{name}' wurde überschrieben.\n\nLöschen Sie das Design in der Liste, um die Standardwerte wiederherzustellen.",
 
       "predefined": {
+        "standard": "Standard",
         "publication": "Publikation",
         "presentation": "Präsentation",
         "tubaf": "TUBAF",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -255,6 +255,7 @@
 
     "font_labels": {
       "title": "Axis Labels Font",
+      "family": "Font Family:",
       "size": "Font Size:",
       "bold": "Bold",
       "italic": "Italic"
@@ -673,6 +674,7 @@
       "standard_overwritten": "Standard design '{name}' has been overwritten.\n\nDelete the design from the list to restore default values.",
 
       "predefined": {
+        "standard": "Standard",
         "publication": "Publication",
         "presentation": "Presentation",
         "tubaf": "TUBAF",

--- a/scatter_plot.py
+++ b/scatter_plot.py
@@ -242,7 +242,7 @@ class ScatterPlotApp(QMainWindow):
         self.custom_ylabel = None  # Custom Y-Achsenbeschriftung
         self.unit_format = 'in'  # Format für Einheiten: 'slash', 'brackets', 'in'
 
-        # Default Plot-Settings aus Config laden (v5.4)
+        # Default Plot-Settings aus Config laden (v5.4, erweitert v7.0.3)
         self.logger.debug("Prüfe auf gespeicherte Standard-Plot-Einstellungen...")
         default_settings = self.config.get_default_plot_settings()
         if default_settings:
@@ -251,11 +251,17 @@ class ScatterPlotApp(QMainWindow):
             self.logger.debug(f"  - Grid Settings: {list(default_settings.get('grid_settings', {}).keys())}")
             self.logger.debug(f"  - Font Settings: {list(default_settings.get('font_settings', {}).keys())}")
             self.logger.debug(f"  - Plot Design: {default_settings.get('current_plot_design', 'Standard')}")
+            self.logger.debug(f"  - Custom X-Label: {default_settings.get('custom_xlabel', None)}")
+            self.logger.debug(f"  - Custom Y-Label: {default_settings.get('custom_ylabel', None)}")
 
             self.legend_settings = default_settings.get('legend_settings', self.legend_settings)
             self.grid_settings = default_settings.get('grid_settings', self.grid_settings)
             self.font_settings = default_settings.get('font_settings', self.font_settings)
             self.current_plot_design = default_settings.get('current_plot_design', 'Standard')
+            self.custom_xlabel = default_settings.get('custom_xlabel', None)
+            self.custom_ylabel = default_settings.get('custom_ylabel', None)
+            if default_settings.get('axis_limits'):
+                self.axis_limits = default_settings.get('axis_limits')
             self.logger.info("Standard-Einstellungen erfolgreich angewendet")
         else:
             self.logger.info("Keine gespeicherten Standard-Einstellungen gefunden, verwende Defaults")
@@ -943,10 +949,12 @@ class ScatterPlotApp(QMainWindow):
 
         self.ax_main.set_xlabel(xlabel, fontsize=self.font_settings.get('labels_size', 12),
                                weight=label_weight, style=label_style,
-                               fontfamily=self.font_settings.get('font_family', 'sans-serif'))
+                               fontfamily=self.font_settings.get('labels_font_family',
+                                                                 self.font_settings.get('font_family', 'sans-serif')))
         self.ax_main.set_ylabel(ylabel, fontsize=self.font_settings.get('labels_size', 12),
                                weight=label_weight, style=label_style,
-                               fontfamily=self.font_settings.get('font_family', 'sans-serif'))
+                               fontfamily=self.font_settings.get('labels_font_family',
+                                                                 self.font_settings.get('font_family', 'sans-serif')))
         self.ax_main.set_xscale(plot_info['xscale'])
         self.ax_main.set_yscale(plot_info['yscale'])
 
@@ -981,7 +989,8 @@ class ScatterPlotApp(QMainWindow):
         for label in self.ax_main.get_xticklabels() + self.ax_main.get_yticklabels():
             label.set_fontweight(tick_weight)
             label.set_fontstyle(tick_style)
-            label.set_fontfamily(self.font_settings.get('font_family', 'sans-serif'))
+            label.set_fontfamily(self.font_settings.get('ticks_font_family',
+                                                        self.font_settings.get('font_family', 'sans-serif')))
 
         # Tick-Label-Rotation (v5.7)
         x_rotation = self.grid_settings.get('x_tick_rotation', 0)

--- a/utils/user_config.py
+++ b/utils/user_config.py
@@ -192,8 +192,9 @@ class UserConfig:
         except Exception as e:
             print(f"Fehler beim Speichern der Config: {e}")
 
-    def save_default_plot_settings(self, legend_settings, grid_settings, font_settings, current_design='Standard'):
-        """Speichert aktuelle Plot-Einstellungen als Standard (v5.4)"""
+    def save_default_plot_settings(self, legend_settings, grid_settings, font_settings, current_design='Standard',
+                                   custom_xlabel=None, custom_ylabel=None, axis_limits=None):
+        """Speichert aktuelle Plot-Einstellungen als Standard (v5.4, erweitert v7.0.3)"""
         from utils.logger import get_logger
         logger = get_logger()
 
@@ -201,7 +202,10 @@ class UserConfig:
             'legend_settings': legend_settings.copy(),
             'grid_settings': grid_settings.copy(),
             'font_settings': font_settings.copy(),
-            'current_plot_design': current_design
+            'current_plot_design': current_design,
+            'custom_xlabel': custom_xlabel,
+            'custom_ylabel': custom_ylabel,
+            'axis_limits': axis_limits.copy() if axis_limits else None
         }
         logger.debug(f"UserConfig: Speichere default_plot_settings (Design: {current_design})")
         self.save_config()


### PR DESCRIPTION
## Summary
This PR adds font family selection capabilities to the axes dialog and improves the persistence of plot designs by storing additional settings (custom axis labels and limits). It also refactors predefined design handling to use internal keys with translation support.

## Key Changes

### Font Family Selection
- Added `QFontComboBox` to axes dialog for selecting font families for both axis labels and tick labels
- Users can now independently choose fonts for labels and ticks (previously only size, bold, italic were configurable)
- Font family settings are stored in `labels_font_family` and `ticks_font_family` keys

### Design Persistence Enhancement
- Extended plot design storage to include:
  - Custom X and Y axis labels (`custom_xlabel`, `custom_ylabel`)
  - Axis limits (`axis_limits`)
- These settings are now saved when creating custom designs and applied when loading designs
- Updated `save_default_plot_settings()` to accept and store these additional parameters

### Design System Refactoring
- Introduced internal design keys (`'standard'`, `'publication'`, `'presentation'`, `'tubaf'`, `'minimalist'`) replacing hardcoded German names
- Added `normalize_design_name()` function for backward compatibility with legacy German design names
- Added helper functions: `get_predefined_design_name()` and `get_all_predefined_design_names()`
- Predefined designs now use translation keys for localization support

### UI/UX Improvements
- Moved signal connections in axes dialog to after all UI elements are created (prevents premature preview updates)
- Added comments clarifying layout row assignments in font settings sections
- Updated translation files (de.json, en.json) with new "family" label for font selection

### Backward Compatibility
- Legacy German design names are automatically converted to internal keys via `normalize_design_name()`
- Existing configurations continue to work without migration

## Technical Details
- Font settings now support fallback to legacy `'font_family'` key if new `'labels_font_family'`/`'ticks_font_family'` keys are not present
- Design comparison logic updated to handle both predefined keys and custom design names
- All version annotations updated to v7.0.3 for new functionality