### PR TITLE
Add missing plot_design translations and axes tab (v7.0.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ScatterForge Plot v7.0.2
+# ScatterForge Plot v7.0.3
 
 **Professionelles Tool für wissenschaftliche Streudaten-Analyse mit publikationsreifer Visualisierung**
 
-![Version](https://img.shields.io/badge/version-7.0.2-blue)
+![Version](https://img.shields.io/badge/version-7.0.3-blue)
 ![Python](https://img.shields.io/badge/python-3.8+-green)
 ![License](https://img.shields.io/badge/license-GPL--3.0-blue)
 
@@ -1011,6 +1011,6 @@ The program code for ScatterForge Plot v7.0+ was written by Claude (Anthropic's 
 
 **Made with ❤️ for the scientific community**
 
-*ScatterForge Plot v7.0.2 - Januar 2026*
+*ScatterForge Plot v7.0.3 - Januar 2026*
 
 ---

--- a/core/version.py
+++ b/core/version.py
@@ -4,7 +4,7 @@ Version Management für ScatterForge Plot
 Zentrale Definition von Version und Metadaten für die Software-Provenienz.
 """
 
-__version__ = "7.0.2"
+__version__ = "7.0.3"
 __app_name__ = "ScatterForge Plot"
 __year__ = "2026"
 __author__ = "TU Bergakademie Freiberg"

--- a/dialogs/design_manager.py
+++ b/dialogs/design_manager.py
@@ -1004,6 +1004,10 @@ class PlotDesignEditDialog(QDialog):
         self.grid_settings = copy.deepcopy(design['grid_settings'])
         self.font_settings = copy.deepcopy(design['font_settings'])
         self.legend_settings = copy.deepcopy(design['legend_settings'])
+        # v7.0.3: Achseneinstellungen
+        self.custom_xlabel = design.get('custom_xlabel', None)
+        self.custom_ylabel = design.get('custom_ylabel', None)
+        self.axis_limits = design.get('axis_limits', None)
 
         self.setWindowTitle(tr("plot_design.edit_title", name=design_name))
         self.resize(600, 700)
@@ -1025,11 +1029,12 @@ class PlotDesignEditDialog(QDialog):
             info_label.setStyleSheet("font-style: italic; color: #888; padding: 5px;")
             layout.addWidget(info_label)
 
-        # Tabs für verschiedene Einstellungs-Kategorien
+        # Tabs für verschiedene Einstellungs-Kategorien (v7.0.3: + Achsen-Tab)
         tabs = QTabWidget()
         tabs.addTab(self.create_grid_tab(), tr("plot_design.tabs.grid"))
         tabs.addTab(self.create_font_tab(), tr("plot_design.tabs.fonts"))
         tabs.addTab(self.create_legend_tab(), tr("plot_design.tabs.legend"))
+        tabs.addTab(self.create_axes_tab(), tr("plot_design.tabs.axes"))
         layout.addWidget(tabs)
 
         # Buttons
@@ -1285,6 +1290,37 @@ class PlotDesignEditDialog(QDialog):
         layout.setRowStretch(6, 1)
         return tab
 
+    def create_axes_tab(self):
+        """Erstellt Achsen-Einstellungen Tab (v7.0.3)"""
+        tab = QWidget()
+        layout = QVBoxLayout(tab)
+
+        # Achsenbeschriftungen
+        axes_group = QGroupBox(tr("plot_design.axes.title"))
+        axes_layout = QGridLayout()
+
+        # X-Achsen-Label
+        axes_layout.addWidget(QLabel(tr("plot_design.axes.x_label")), 0, 0)
+        self.axes_xlabel_edit = QLineEdit()
+        self.axes_xlabel_edit.setPlaceholderText(tr("plot_design.axes.x_label_placeholder"))
+        if self.custom_xlabel:
+            self.axes_xlabel_edit.setText(self.custom_xlabel)
+        axes_layout.addWidget(self.axes_xlabel_edit, 0, 1)
+
+        # Y-Achsen-Label
+        axes_layout.addWidget(QLabel(tr("plot_design.axes.y_label")), 1, 0)
+        self.axes_ylabel_edit = QLineEdit()
+        self.axes_ylabel_edit.setPlaceholderText(tr("plot_design.axes.y_label_placeholder"))
+        if self.custom_ylabel:
+            self.axes_ylabel_edit.setText(self.custom_ylabel)
+        axes_layout.addWidget(self.axes_ylabel_edit, 1, 1)
+
+        axes_group.setLayout(axes_layout)
+        layout.addWidget(axes_group)
+
+        layout.addStretch()
+        return tab
+
     def choose_major_color(self):
         """Wählt Farbe für Haupt-Grid"""
         color = QColorDialog.getColor(QColor(self.major_color), self, tr("plot_design.grid.choose_major_color"))
@@ -1357,7 +1393,11 @@ class PlotDesignEditDialog(QDialog):
                 'frameon': self.legend_frameon.isChecked(),
                 'shadow': self.legend_shadow.isChecked(),
                 'fancybox': self.legend_fancybox.isChecked()
-            }
+            },
+            # v7.0.3: Achseneinstellungen
+            'custom_xlabel': self.axes_xlabel_edit.text().strip() if self.axes_xlabel_edit.text().strip() else None,
+            'custom_ylabel': self.axes_ylabel_edit.text().strip() if self.axes_ylabel_edit.text().strip() else None,
+            'axis_limits': self.axis_limits
         }
 
         # In Config speichern

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -3,7 +3,7 @@
   "_language_code": "de",
 
   "app": {
-    "title": "ScatterForge Plot v7.0.2"
+    "title": "ScatterForge Plot v7.0.3"
   },
 
   "menu": {
@@ -680,6 +680,65 @@
         "tubaf": "TUBAF",
         "minimalist": "Minimalistisch"
       }
+    }
+  },
+
+  "plot_design": {
+    "edit_title": "Plot-Design bearbeiten: {name}",
+    "name": "Design-Name:",
+    "name_placeholder": "Leer lassen, um '{name}' zu überschreiben",
+    "default_info": "ℹ️  Standard-Designs werden beim Speichern überschrieben und können durch Löschen aus der Liste wiederhergestellt werden.",
+    "name_required": "Bitte geben Sie einen Design-Namen ein.",
+    "saved": "Design '{name}' wurde gespeichert.",
+    "default_overwritten": "Standard-Design '{name}' wurde überschrieben.\n\nLöschen Sie das Design aus der Liste, um die Standardwerte wiederherzustellen.",
+
+    "tabs": {
+      "grid": "Grid",
+      "fonts": "Schriften",
+      "legend": "Legende",
+      "axes": "Achsen"
+    },
+
+    "grid": {
+      "major": "Haupt-Grid",
+      "minor": "Neben-Grid",
+      "enabled": "Aktiviert",
+      "axis": "Achse:",
+      "linestyle": "Linienstil:",
+      "linewidth": "Linienbreite:",
+      "alpha": "Transparenz (Alpha):",
+      "color": "Farbe:",
+      "choose_major_color": "Haupt-Grid-Farbe wählen",
+      "choose_minor_color": "Neben-Grid-Farbe wählen"
+    },
+
+    "font": {
+      "family": "Schriftart:",
+      "use_math_text": "Math Text verwenden (für Exponenten)",
+      "title": "Titel",
+      "labels": "Achsenbeschriftungen",
+      "ticks": "Achsen-Werte (Ticks)",
+      "legend": "Legende",
+      "size": "Größe:",
+      "bold": "Fett",
+      "italic": "Kursiv"
+    },
+
+    "legend": {
+      "position": "Position:",
+      "columns": "Anzahl Spalten:",
+      "alpha": "Transparenz (Alpha):",
+      "show_frame": "Rahmen anzeigen",
+      "shadow": "Schatten",
+      "rounded_corners": "Abgerundete Ecken"
+    },
+
+    "axes": {
+      "title": "Achseneinstellungen",
+      "x_label": "X-Achsen-Beschriftung:",
+      "y_label": "Y-Achsen-Beschriftung:",
+      "x_label_placeholder": "Leer lassen für automatische Beschriftung",
+      "y_label_placeholder": "Leer lassen für automatische Beschriftung"
     }
   },
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -3,7 +3,7 @@
   "_language_code": "en",
 
   "app": {
-    "title": "ScatterForge Plot v7.0.2"
+    "title": "ScatterForge Plot v7.0.3"
   },
 
   "menu": {
@@ -680,6 +680,65 @@
         "tubaf": "TUBAF",
         "minimalist": "Minimalist"
       }
+    }
+  },
+
+  "plot_design": {
+    "edit_title": "Edit Plot Design: {name}",
+    "name": "Design Name:",
+    "name_placeholder": "Keep empty to overwrite '{name}'",
+    "default_info": "ℹ️  Standard designs will be overwritten when saved and can be restored by deleting them from the list.",
+    "name_required": "Please enter a design name.",
+    "saved": "Design '{name}' has been saved.",
+    "default_overwritten": "Standard design '{name}' has been overwritten.\n\nDelete the design from the list to restore default values.",
+
+    "tabs": {
+      "grid": "Grid",
+      "fonts": "Fonts",
+      "legend": "Legend",
+      "axes": "Axes"
+    },
+
+    "grid": {
+      "major": "Main Grid",
+      "minor": "Secondary Grid",
+      "enabled": "Enabled",
+      "axis": "Axis:",
+      "linestyle": "Line Style:",
+      "linewidth": "Line Width:",
+      "alpha": "Transparency (Alpha):",
+      "color": "Color:",
+      "choose_major_color": "Choose Main Grid Color",
+      "choose_minor_color": "Choose Secondary Grid Color"
+    },
+
+    "font": {
+      "family": "Font Family:",
+      "use_math_text": "Use Math Text (for exponents)",
+      "title": "Title",
+      "labels": "Axis Labels",
+      "ticks": "Axis Values (Ticks)",
+      "legend": "Legend",
+      "size": "Size:",
+      "bold": "Bold",
+      "italic": "Italic"
+    },
+
+    "legend": {
+      "position": "Position:",
+      "columns": "Number of Columns:",
+      "alpha": "Transparency (Alpha):",
+      "show_frame": "Show Frame",
+      "shadow": "Shadow",
+      "rounded_corners": "Rounded Corners"
+    },
+
+    "axes": {
+      "title": "Axis Settings",
+      "x_label": "X-Axis Label:",
+      "y_label": "Y-Axis Label:",
+      "x_label_placeholder": "Leave empty for automatic label",
+      "y_label_placeholder": "Leave empty for automatic label"
     }
   },
 


### PR DESCRIPTION
This commit addresses user feedback:

1. Added missing translations for plot_design:
   - Added complete plot_design section to en.json and de.json
   - Includes translations for all grid, font, legend, and axes settings
   - Covers edit_title, name, name_placeholder, default_info
   - Added saved, default_overwritten, name_required messages
   - Added tabs translations (grid, fonts, legend, axes)
   - Added grid settings (major, minor, enabled, axis, linestyle, etc.)
   - Added font settings (family, use_math_text, title, labels, ticks, legend)
   - Added legend settings (position, columns, alpha, show_frame, shadow, rounded_corners)
   - Added axes settings (title, x_label, y_label, placeholders)

2. Created new Axes tab in Plot Design Edit Dialog:
   - Added create_axes_tab() method to PlotDesignEditDialog
   - Users can now set custom xlabel and ylabel in plot designs
   - Axis labels are saved/loaded with designs
   - Includes axis_limits support (already implemented earlier)

3. Updated version number to 7.0.3:
   - core/version.py: __version__ = "7.0.3"
   - i18n/translations/en.json: "ScatterForge Plot v7.0.3"
   - i18n/translations/de.json: "ScatterForge Plot v7.0.3"
   - README.md: Updated header and footer to v7.0.3

All changes validated with syntax checks (Python and JSON).