### PR TITLE
Add file path update feature for datasets (v7.0.4)

### DIFF
--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -77,6 +77,7 @@
     "apply_style": "Stil anwenden",
     "reset_color": "Farbe zurücksetzen",
     "set_plot_limits": "Plotgrenzen setzen...",
+    "update_filepath": "Dateipfad aktualisieren...",
     "delete": "Löschen"
   },
 
@@ -119,7 +120,11 @@
     "session_loaded": "Session geladen",
     "session_save_error": "Fehler beim Speichern:\n{error}",
     "session_load_error": "Fehler beim Laden:\n{error}",
-    "language_changed_restart": "Die Sprachänderung wird beim nächsten Programmstart wirksam."
+    "language_changed_restart": "Die Sprachänderung wird beim nächsten Programmstart wirksam.",
+    "current_filepath_exists": "Aktueller Pfad: {filepath}",
+    "current_filepath_missing": "Aktueller Pfad (nicht gefunden): {filepath}",
+    "filepath_updated": "Dateipfad für '{name}' erfolgreich aktualisiert:\n{filepath}",
+    "filepath_update_error": "Fehler beim Laden der neuen Datei:\n{error}"
   },
 
   "export": {

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -77,6 +77,7 @@
     "apply_style": "Apply Style",
     "reset_color": "Reset Color",
     "set_plot_limits": "Set Plot Limits...",
+    "update_filepath": "Update File Path...",
     "delete": "Delete"
   },
 
@@ -119,7 +120,11 @@
     "session_loaded": "Session loaded",
     "session_save_error": "Error saving:\n{error}",
     "session_load_error": "Error loading:\n{error}",
-    "language_changed_restart": "The language change will take effect on next program start."
+    "language_changed_restart": "The language change will take effect on next program start.",
+    "current_filepath_exists": "Current path: {filepath}",
+    "current_filepath_missing": "Current path (not found): {filepath}",
+    "filepath_updated": "File path for '{name}' successfully updated:\n{filepath}",
+    "filepath_update_error": "Error loading new file:\n{error}"
   },
 
   "export": {


### PR DESCRIPTION
Implements user-requested feature to update dataset file paths via context menu. This allows users to:
1. Update missing file paths after loading sessions on different PCs
2. Replace data files with updated versions

Features:
- New context menu option "Update File Path..." for datasets
- File dialog to select new data file
- Automatic data reload with error handling
- Rollback on load errors
- Updates display label if name was derived from filename
- Full German/English translations

Files changed:
- scatter_plot.py: Added update_dataset_filepath() method and context menu entry
- i18n/translations/de.json: Added translations for new feature
- i18n/translations/en.json: Added translations for new feature

https://claude.ai/code/session_636vm